### PR TITLE
Add wrapper tool for sde indexed search

### DIFF
--- a/akd_ext/structures.py
+++ b/akd_ext/structures.py
@@ -22,11 +22,3 @@ class SDEIndexedDocumentType(StrEnum):
     DOCUMENTATION = "Documentation"
     SOFTWARE_TOOLS = "Software and Tools"
     MISSIONS_INSTRUMENTS = "Missions and Instruments"
-
-
-class TextSearchType(StrEnum):
-    """Search type for SDE queries."""
-
-    HYBRID = "hybrid"  # Vector + keyword search
-    VECTOR = "vector"  # Semantic search only
-    KEYWORD = "keyword"  # Text-based search only

--- a/akd_ext/structures.py
+++ b/akd_ext/structures.py
@@ -1,0 +1,32 @@
+"""Common data structures and enums for akd_ext."""
+
+from enum import StrEnum
+
+
+class NASASMDDivision(StrEnum):
+    """NASA Science Mission Directorate (SMD) divisions."""
+
+    ASTROPHYSICS = "Astrophysics"
+    HELIOPHYSICS = "Heliophysics"
+    EARTH_SCIENCE = "Earth Science"
+    BIOLOGICAL_PHYSICAL_SCIENCES = "Biological and Physical Sciences"
+    PLANETARY_SCIENCE = "Planetary Science"
+    OTHER = "Other"
+
+
+class SDEIndexedDocumentType(StrEnum):
+    """Document types available in the SDE."""
+
+    DATA = "Data"
+    IMAGES = "Images"
+    DOCUMENTATION = "Documentation"
+    SOFTWARE_TOOLS = "Software and Tools"
+    MISSIONS_INSTRUMENTS = "Missions and Instruments"
+
+
+class TextSearchType(StrEnum):
+    """Search type for SDE queries."""
+
+    HYBRID = "hybrid"  # Vector + keyword search
+    VECTOR = "vector"  # Semantic search only
+    KEYWORD = "keyword"  # Text-based search only

--- a/akd_ext/tools/__init__.py
+++ b/akd_ext/tools/__init__.py
@@ -7,12 +7,12 @@ from .sde_search import (
     SDESearchToolConfig,
     SDESearchToolInputSchema,
     SDESearchToolOutputSchema,
+)
 from .code_search.repository_search import (
     RepositorySearchTool,
     RepositorySearchToolInputSchema,
     RepositorySearchToolOutputSchema,
     RepositorySearchToolConfig,
-
 )
 
 __all__ = [

--- a/akd_ext/tools/__init__.py
+++ b/akd_ext/tools/__init__.py
@@ -1,5 +1,21 @@
 """Tools module for akd_ext."""
 
 from .dummy import DummyInputSchema, DummyOutputSchema, DummyTool
+from .sde_search import (
+    SDEDocument,
+    SDESearchTool,
+    SDESearchToolConfig,
+    SDESearchToolInputSchema,
+    SDESearchToolOutputSchema,
+)
 
-__all__ = ["DummyTool", "DummyInputSchema", "DummyOutputSchema"]
+__all__ = [
+    "DummyTool",
+    "DummyInputSchema",
+    "DummyOutputSchema",
+    "SDESearchTool",
+    "SDESearchToolInputSchema",
+    "SDESearchToolOutputSchema",
+    "SDESearchToolConfig",
+    "SDEDocument",
+]

--- a/akd_ext/tools/sde_search.py
+++ b/akd_ext/tools/sde_search.py
@@ -1,0 +1,183 @@
+"""
+NASA Science Discovery Engine (SDE) search tool.
+
+This tool wraps the SDE Elastic Wrapper API to enable searching NASA's Science
+Discovery Engine for relevant scientific documents, datasets, and resources using
+natural language queries.
+"""
+
+import httpx
+from akd._base import InputSchema, OutputSchema
+from akd.tools import BaseTool, BaseToolConfig
+from pydantic import BaseModel, Field
+
+from akd_ext.structures import SDEIndexedDocumentType, NASASMDDivision, TextSearchType
+
+
+class SDESearchToolConfig(BaseToolConfig):
+    """Configuration for the SDE Search Tool."""
+
+    api_base_url: str = Field(
+        default="https://dyejsbdumgpqz.cloudfront.net",
+        description="Base URL for the SDE API",
+    )
+    timeout: float = Field(
+        default=30.0,
+        description="HTTP request timeout in seconds",
+    )
+    division: NASASMDDivision | None = Field(
+        None,
+        description="Filter results by NASA SMD division",
+    )
+    search_type: TextSearchType = Field(
+        default=TextSearchType.HYBRID,
+        description="Search method: hybrid (vector+keyword), vector (semantic), or keyword (text)",
+    )
+
+
+class SDEDocument(BaseModel):
+    """
+    A single document result from SDE search.
+
+    Parsed from the HitBase structure returned by the SDE Elastic Wrapper API.
+    Maps common fields from multiple index types (web, CMR, PDS3/4, SPASE, GCN, etc.)
+    into a unified structure for downstream use.
+    """
+
+    title: str = Field(..., description="Title of the document")
+    url: str = Field(..., description="URL to access the document")
+    snippet: str = Field(..., description="Snippet or abstract of the document content (max 500 chars)")
+    score: float = Field(..., description="Relevance score from OpenSearch")
+    division: str | None = Field(None, description="NASA SMD division (e.g., Astrophysics, Planetary Science)")
+    doc_type: str | None = Field(None, description="Document type (e.g., Data, Documentation, Software and Tools)")
+    source: str | None = Field(None, description="Source index (e.g., sde-web, sde-cmr, sde-pds4, sde-code)")
+
+
+class SDESearchToolInputSchema(InputSchema):
+    """Input schema for SDE search queries."""
+
+    query: str = Field(..., description="Natural language search query")
+    limit: int = Field(default=10, ge=1, le=100, description="Maximum number of results to return")
+
+    doc_type: SDEIndexedDocumentType | None = Field(
+        None,
+        description="Filter results by document type",
+    )
+
+
+class SDESearchToolOutputSchema(OutputSchema):
+    """Output schema for SDE search results."""
+
+    documents: list[SDEDocument] = Field(..., description="List of matching documents from SDE")
+    total_count: int = Field(..., description="Total number of results available")
+    query_used: str = Field(..., description="The query that was executed")
+
+
+# not basing it on SearchTool because this just a wrapper around SDE API
+class SDESearchTool(BaseTool[SDESearchToolInputSchema, SDESearchToolOutputSchema]):
+    """
+    Search the NASA Science Discovery Engine for scientific documents and resources.
+
+    This tool queries the SDE API to find datasets, documentation, publications,
+    software, and other scientific resources across NASA's Science Mission Directorate
+    divisions (Astrophysics, Earth Science, Heliophysics, Planetary Science, etc.).
+    """
+
+    input_schema = SDESearchToolInputSchema
+    output_schema = SDESearchToolOutputSchema
+    config_schema = SDESearchToolConfig
+
+    async def _arun(self, params: SDESearchToolInputSchema) -> SDESearchToolOutputSchema:
+        """Execute SDE search query and return formatted results."""
+        # Build request payload
+        request_body = {
+            "search_term": params.query,
+            "page": 1,
+            "pageSize": params.limit,
+            "search_type": self.config.search_type.value,
+        }
+
+        # Add optional filters
+        filters = {}
+        if self.config.division:
+            filters["division"] = [self.config.division.value]
+        if params.doc_type:
+            filters["document_type"] = [params.doc_type.value]
+
+        if filters:
+            request_body["filters"] = filters
+
+        print(f"Request body for SDE API: {request_body}")
+
+        # Make API request
+        async with httpx.AsyncClient(timeout=self.config.timeout) as client:
+            try:
+                response = await client.post(
+                    f"{self.config.api_base_url}/api/search",
+                    json=request_body,
+                )
+                response.raise_for_status()
+                data = response.json()
+            except httpx.TimeoutException as e:
+                msg = f"SDE API request timed out after {self.config.timeout}s"
+                raise TimeoutError(msg) from e
+            except httpx.HTTPStatusError as e:
+                msg = f"SDE API returned error status {e.response.status_code}: {e.response.text}"
+                raise RuntimeError(msg) from e
+            except Exception as e:
+                msg = f"Failed to query SDE API: {e}"
+                raise RuntimeError(msg) from e
+
+        # Parse response
+        if not data.get("success", False):
+            msg = f"SDE API returned unsuccessful response: {data}"
+            raise RuntimeError(msg)
+
+        documents = []
+        for doc in data.get("documents", []):
+            # Parse HitBase structure
+            # Extract core fields
+            score = doc.get("score") or doc.get("_score") or 0.0
+            source_index = doc.get("index") or doc.get("_index") or "unknown"
+
+            # Extract title with multiple fallbacks
+            title = doc.get("title") or doc.get("name") or doc.get("id") or "Untitled"
+
+            # Extract URL with fallbacks
+            url = doc.get("url") or doc.get("readme_url") or ""
+
+            # Extract snippet/description with priority order
+            snippet = (
+                doc.get("full_text")
+                or doc.get("data_product_desc")
+                or doc.get("description")
+                or doc.get("relevant_content")
+                or ""
+            )
+
+            # Extract metadata from HitBase common fields
+            division = doc.get("division")
+            doc_type = doc.get("document_type")
+
+            # Determine source from api_source or index name
+            source = doc.get("api_source") or source_index
+
+            documents.append(
+                SDEDocument(
+                    title=title,
+                    url=url,
+                    snippet=snippet,
+                    score=score,
+                    division=division,
+                    doc_type=doc_type,
+                    source=source,
+                )
+            )
+
+        total_count = data.get("total_count", len(documents))
+
+        return SDESearchToolOutputSchema(
+            documents=documents,
+            total_count=total_count,
+            query_used=params.query,
+        )

--- a/akd_ext/tools/sde_search.py
+++ b/akd_ext/tools/sde_search.py
@@ -98,6 +98,54 @@ class SDESearchTool(BaseTool[SDESearchToolInputSchema, SDESearchToolOutputSchema
     output_schema = SDESearchToolOutputSchema
     config_schema = SDESearchToolConfig
 
+    def _parse_document(self, doc: dict, query: str) -> SDEDocument:
+        """
+        Parse a single document from the SDE API response.
+
+        Args:
+            doc: Raw document dictionary from the API response
+            query: The search query that produced this result
+
+        Returns:
+            SDEDocument: Parsed and structured document
+        """
+        # Extract core fields
+        score = doc.get("score") or doc.get("_score") or 0.0
+        source_index = doc.get("index") or doc.get("_index") or "unknown"
+
+        # Extract title with multiple fallbacks
+        title = doc.get("title") or doc.get("name") or doc.get("id") or "Untitled"
+
+        # Extract URL with fallbacks
+        url = doc.get("url") or doc.get("readme_url") or ""
+
+        # Extract snippet/description with priority order
+        snippet = (
+            doc.get("full_text")
+            or doc.get("data_product_desc")
+            or doc.get("description")
+            or doc.get("relevant_content")
+            or ""
+        )
+
+        # Extract metadata from HitBase common fields
+        division = doc.get("division")
+        doc_type = doc.get("document_type")
+
+        # Determine source from api_source or index name
+        source = doc.get("api_source") or source_index
+
+        return SDEDocument(
+            query=query,
+            title=title,
+            content=snippet,
+            score=score,
+            url=url,
+            division=NASASMDDivision(division) if division else None,
+            doc_type=SDEIndexedDocumentType(doc_type) if doc_type else None,
+            source=source,
+        )
+
     async def _arun(self, params: SDESearchToolInputSchema) -> SDESearchToolOutputSchema:
         """Execute SDE search query and return formatted results."""
         # Build request payload
@@ -144,47 +192,7 @@ class SDESearchTool(BaseTool[SDESearchToolInputSchema, SDESearchToolOutputSchema
             msg = f"SDE API returned unsuccessful response: {data}"
             raise RuntimeError(msg)
 
-        documents = []
-        for doc in data.get("documents", []):
-            # Parse HitBase structure
-            # Extract core fields
-            score = doc.get("score") or doc.get("_score") or 0.0
-            source_index = doc.get("index") or doc.get("_index") or "unknown"
-
-            # Extract title with multiple fallbacks
-            title = doc.get("title") or doc.get("name") or doc.get("id") or "Untitled"
-
-            # Extract URL with fallbacks
-            url = doc.get("url") or doc.get("readme_url") or ""
-
-            # Extract snippet/description with priority order
-            snippet = (
-                doc.get("full_text")
-                or doc.get("data_product_desc")
-                or doc.get("description")
-                or doc.get("relevant_content")
-                or ""
-            )
-
-            # Extract metadata from HitBase common fields
-            division = doc.get("division")
-            doc_type = doc.get("document_type")
-
-            # Determine source from api_source or index name
-            source = doc.get("api_source") or source_index
-
-            documents.append(
-                SDEDocument(
-                    query=params.query,
-                    title=title,
-                    content=snippet,
-                    score=score,
-                    url=url,
-                    division=NASASMDDivision(division) if division else None,
-                    doc_type=SDEIndexedDocumentType(doc_type) if doc_type else None,
-                    source=source,
-                )
-            )
+        documents = [self._parse_document(doc, params.query) for doc in data.get("documents", [])]
 
         return SDESearchToolOutputSchema(
             results=documents,

--- a/akd_ext/tools/sde_search.py
+++ b/akd_ext/tools/sde_search.py
@@ -6,6 +6,7 @@ Discovery Engine for relevant scientific documents, datasets, and resources usin
 natural language queries.
 """
 
+import asyncio
 import os
 import httpx
 from akd._base import InputSchema
@@ -37,6 +38,20 @@ class SDESearchToolConfig(BaseToolConfig):
     search_type: Literal["hybrid", "vector", "keyword"] = Field(
         default="hybrid",
         description="Search type: 'hybrid' (vector + keyword), 'vector' (semantic), 'keyword' (text-based)",
+    )
+    validate_urls: bool = Field(
+        default=True,
+        description="Validate document URLs with HTTP HEAD requests to filter out 404s",
+    )
+    url_check_timeout: float = Field(
+        default=5.0,
+        description="Timeout for individual URL validation requests in seconds",
+    )
+    result_multiplier: float = Field(
+        default=2.0,
+        ge=1.0,
+        le=10.0,
+        description="Multiplier for initial results to fetch (e.g., 2.0 fetches 2x limit from API before filtering)",
     )
 
 
@@ -84,7 +99,6 @@ class SDESearchToolOutputSchema(SearchToolOutputSchema):
     results: list[SDEDocument] = Field(..., description="List of matching documents from SDE")
 
 
-# not basing it on SearchTool because this just a wrapper around SDE API
 class SDESearchTool(BaseTool[SDESearchToolInputSchema, SDESearchToolOutputSchema]):
     """
     Search the NASA Science Discovery Engine for scientific documents and resources.
@@ -97,6 +111,27 @@ class SDESearchTool(BaseTool[SDESearchToolInputSchema, SDESearchToolOutputSchema
     input_schema = SDESearchToolInputSchema
     output_schema = SDESearchToolOutputSchema
     config_schema = SDESearchToolConfig
+
+    async def _check_url_exists(self, url: str) -> bool:
+        """
+        Check if a URL is accessible using HTTP HEAD request.
+
+        Args:
+            url: The URL to check
+
+        Returns:
+            bool: True if URL is accessible (status < 400), False otherwise
+        """
+        if not url:
+            return False
+
+        try:
+            async with httpx.AsyncClient(timeout=self.config.url_check_timeout, follow_redirects=True) as client:
+                response = await client.head(url)
+                return response.status_code < 400
+        except Exception as e:
+            logger.debug(f"URL check failed for {url}: {e}")
+            return False
 
     def _parse_document(self, doc: dict, query: str) -> SDEDocument:
         """
@@ -148,11 +183,19 @@ class SDESearchTool(BaseTool[SDESearchToolInputSchema, SDESearchToolOutputSchema
 
     async def _arun(self, params: SDESearchToolInputSchema) -> SDESearchToolOutputSchema:
         """Execute SDE search query and return formatted results."""
+        # Calculate fetch size: if URL validation is enabled, fetch more to account for filtering
+        fetch_size = params.limit
+        if self.config.validate_urls:
+            fetch_size = min(int(params.limit * self.config.result_multiplier), 100)
+            logger.debug(
+                f"Fetching {fetch_size} results (limit={params.limit}, multiplier={self.config.result_multiplier})"
+            )
+
         # Build request payload
         request_body = {
             "search_term": params.query,
             "page": 1,
-            "pageSize": params.limit,
+            "pageSize": fetch_size,
             "search_type": self.config.search_type,
         }
 
@@ -194,10 +237,42 @@ class SDESearchTool(BaseTool[SDESearchToolInputSchema, SDESearchToolOutputSchema
 
         documents = [self._parse_document(doc, params.query) for doc in data.get("documents", [])]
 
+        # Validate URLs if configured
+        if self.config.validate_urls:
+            logger.debug(f"Validating {len(documents)} document URLs")
+            # Check all URLs in parallel using asyncio.gather
+            url_checks = await asyncio.gather(
+                *[self._check_url_exists(doc.url) for doc in documents],
+                return_exceptions=True,
+            )
+
+            # Filter out documents with invalid URLs
+            validated_documents = []
+            for doc, is_valid in zip(documents, url_checks, strict=False):
+                # Handle exceptions as invalid
+                if isinstance(is_valid, Exception):
+                    logger.debug(f"URL validation exception for {doc.url}: {is_valid}")
+                    continue
+                if is_valid:
+                    validated_documents.append(doc)
+                else:
+                    logger.debug(f"Filtered out document with inaccessible URL: {doc.url}")
+
+            documents = validated_documents
+            logger.debug(f"Retained {len(documents)} documents after URL validation")
+
+        # Limit results to requested limit (in case we fetched more for validation)
+        final_documents = documents[: params.limit]
+
+        if len(documents) > params.limit:
+            logger.debug(f"Truncating {len(documents)} results to requested limit of {params.limit}")
+
         return SDESearchToolOutputSchema(
-            results=documents,
+            results=final_documents,
             extra={
                 "total_count": data.get("total_count", 0),
                 "query_used": params.query,
+                "filtered_count": len(final_documents) if self.config.validate_urls else None,
+                "requested_limit": params.limit,
             },
         )

--- a/akd_ext/tools/sde_search.py
+++ b/akd_ext/tools/sde_search.py
@@ -40,7 +40,7 @@ class SDESearchToolConfig(BaseToolConfig):
         description="Search type: 'hybrid' (vector + keyword), 'vector' (semantic), 'keyword' (text-based)",
     )
     validate_urls: bool = Field(
-        default=True,
+        default=False,
         description="Validate document URLs with HTTP HEAD requests to filter out 404s",
     )
     url_check_timeout: float = Field(
@@ -123,7 +123,7 @@ class SDESearchTool(BaseTool[SDESearchToolInputSchema, SDESearchToolOutputSchema
                    or "keyword" (text-based only). Fixed at tool instantiation.
     - division: Optional NASA SMD division filter (Astrophysics, Earth Science, Heliophysics,
                 Planetary Science). If set, all searches are scoped to this division.
-    - validate_urls: Whether to validate result URLs with HTTP HEAD requests (default: True).
+    - validate_urls: Whether to validate result URLs with HTTP HEAD requests (default: False).
                      Filters out inaccessible resources.
     - result_multiplier: When validate_urls=True, fetches this multiple of the limit to account
                         for filtered results (default: 2.0, range: 1.0-10.0)

--- a/akd_ext/tools/sde_search.py
+++ b/akd_ext/tools/sde_search.py
@@ -101,11 +101,43 @@ class SDESearchToolOutputSchema(SearchToolOutputSchema):
 
 class SDESearchTool(BaseTool[SDESearchToolInputSchema, SDESearchToolOutputSchema]):
     """
-    Search the NASA Science Discovery Engine for scientific documents and resources.
+    Search NASA's Science Discovery Engine (SDE) using the unified /api/search endpoint.
 
-    This tool queries the SDE API to find datasets, documentation, publications,
-    software, and other scientific resources across NASA's Science Mission Directorate
-    divisions (Astrophysics, Earth Science, Heliophysics, Planetary Science, etc.).
+    The Science Discovery Engine (SDE) is NASA's centralized search platform that indexes
+    scientific data, publications, and resources from multiple NASA data sources including
+    CMR (Earth observation), PDS (planetary science), SPASE (heliophysics), GCN (astronomy),
+    code repositories, and documentation.
+
+    This tool uses the /api/search endpoint which provides cross-source search with vector, keyword and hybrid
+    (vector + keyword) semantic search capabilities, returning unified results across all
+    indexed NASA content.
+
+    Input parameters (query-time, LLM-controllable):
+    - query: Natural language search query (e.g., "Mars rover spectroscopy data")
+    - limit: Maximum number of results to return (1-100, default: 10)
+    - doc_type: Optional filter by document type (Data, Documentation, Software and Tools,
+                Images, Missions and Instruments)
+
+    Configuration parameters (instance-time, user-controlled):
+    - search_type: Search mode - "hybrid" (default, vector+keyword), "vector" (semantic only),
+                   or "keyword" (text-based only). Fixed at tool instantiation.
+    - division: Optional NASA SMD division filter (Astrophysics, Earth Science, Heliophysics,
+                Planetary Science). If set, all searches are scoped to this division.
+    - validate_urls: Whether to validate result URLs with HTTP HEAD requests (default: True).
+                     Filters out inaccessible resources.
+    - result_multiplier: When validate_urls=True, fetches this multiple of the limit to account
+                        for filtered results (default: 2.0, range: 1.0-10.0)
+    - timeout: HTTP request timeout in seconds (default: 30.0)
+    - url_check_timeout: Timeout for URL validation requests in seconds (default: 5.0)
+
+    Returns documents with:
+    - title: Document or dataset title
+    - url: Direct link to the resource
+    - content: Description, abstract, or relevant text snippet
+    - score: Relevance score from search engine
+    - division: NASA SMD division (Astrophysics, Earth Science, Heliophysics, Planetary Science)
+    - doc_type: Type of document/resource
+    - source: Origin data source (sde-cmr, sde-pds4, sde-web, sde-code, etc.)
     """
 
     input_schema = SDESearchToolInputSchema

--- a/akd_ext/tools/sde_search.py
+++ b/akd_ext/tools/sde_search.py
@@ -6,19 +6,24 @@ Discovery Engine for relevant scientific documents, datasets, and resources usin
 natural language queries.
 """
 
+import os
 import httpx
-from akd._base import InputSchema, OutputSchema
+from akd._base import InputSchema
+from akd.tools.search import SearchToolOutputSchema
+from akd.structures import SearchResult
 from akd.tools import BaseTool, BaseToolConfig
-from pydantic import BaseModel, Field
+from pydantic import Field
+from typing import Literal
+from loguru import logger
 
-from akd_ext.structures import SDEIndexedDocumentType, NASASMDDivision, TextSearchType
+from akd_ext.structures import SDEIndexedDocumentType, NASASMDDivision
 
 
 class SDESearchToolConfig(BaseToolConfig):
     """Configuration for the SDE Search Tool."""
 
-    api_base_url: str = Field(
-        default="https://dyejsbdumgpqz.cloudfront.net",
+    base_url: str = Field(
+        default=os.getenv("SDE_BASE_URL", "https://dyejsbdumgpqz.cloudfront.net"),
         description="Base URL for the SDE API",
     )
     timeout: float = Field(
@@ -29,30 +34,38 @@ class SDESearchToolConfig(BaseToolConfig):
         None,
         description="Filter results by NASA SMD division",
     )
-    search_type: TextSearchType = Field(
-        default=TextSearchType.HYBRID,
-        description="Search method: hybrid (vector+keyword), vector (semantic), or keyword (text)",
+    search_type: Literal["hybrid", "vector", "keyword"] = Field(
+        default="hybrid",
+        description="Search type: 'hybrid' (vector + keyword), 'vector' (semantic), 'keyword' (text-based)",
     )
 
 
-class SDEDocument(BaseModel):
+class SDEDocument(SearchResult):
     """
     A single document result from SDE search.
 
-    Parsed from the HitBase structure returned by the SDE Elastic Wrapper API.
-    Maps common fields from multiple index types (web, CMR, PDS3/4, SPASE, GCN, etc.)
-    into a unified structure for downstream use.
+    Extends SearchResult with SDE-specific fields. Parsed from the HitBase structure
+    returned by the SDE Elastic Wrapper API. Maps common fields from multiple index
+    types (web, CMR, PDS3/4, SPASE, GCN, etc.) into a unified structure.
+
+    Common fields inherited from SearchResult:
+    - query: Search query that produced this result
+    - title: Document title
+    - content: Snippet or abstract (mapped from snippet field)
+    - score: Relevance score from OpenSearch
     """
 
-    title: str = Field(..., description="Title of the document")
     url: str = Field(..., description="URL to access the document")
-    snippet: str = Field(..., description="Snippet or abstract of the document content (max 500 chars)")
-    score: float = Field(..., description="Relevance score from OpenSearch")
-    division: str | None = Field(None, description="NASA SMD division (e.g., Astrophysics, Planetary Science)")
-    doc_type: str | None = Field(None, description="Document type (e.g., Data, Documentation, Software and Tools)")
+    division: NASASMDDivision | None = Field(
+        None, description="NASA SMD division (e.g., Astrophysics, Planetary Science)"
+    )
+    doc_type: SDEIndexedDocumentType | None = Field(
+        None, description="Document type (e.g., Data, Documentation, Software and Tools)"
+    )
     source: str | None = Field(None, description="Source index (e.g., sde-web, sde-cmr, sde-pds4, sde-code)")
 
 
+# cannot use SearchToolInputSchema because it has plural 'queries' field
 class SDESearchToolInputSchema(InputSchema):
     """Input schema for SDE search queries."""
 
@@ -65,12 +78,10 @@ class SDESearchToolInputSchema(InputSchema):
     )
 
 
-class SDESearchToolOutputSchema(OutputSchema):
+class SDESearchToolOutputSchema(SearchToolOutputSchema):
     """Output schema for SDE search results."""
 
-    documents: list[SDEDocument] = Field(..., description="List of matching documents from SDE")
-    total_count: int = Field(..., description="Total number of results available")
-    query_used: str = Field(..., description="The query that was executed")
+    results: list[SDEDocument] = Field(..., description="List of matching documents from SDE")
 
 
 # not basing it on SearchTool because this just a wrapper around SDE API
@@ -94,7 +105,7 @@ class SDESearchTool(BaseTool[SDESearchToolInputSchema, SDESearchToolOutputSchema
             "search_term": params.query,
             "page": 1,
             "pageSize": params.limit,
-            "search_type": self.config.search_type.value,
+            "search_type": self.config.search_type,
         }
 
         # Add optional filters
@@ -107,13 +118,13 @@ class SDESearchTool(BaseTool[SDESearchToolInputSchema, SDESearchToolOutputSchema
         if filters:
             request_body["filters"] = filters
 
-        print(f"Request body for SDE API: {request_body}")
+        logger.debug(f"Request body for SDE API: {request_body}")
 
         # Make API request
         async with httpx.AsyncClient(timeout=self.config.timeout) as client:
             try:
                 response = await client.post(
-                    f"{self.config.api_base_url}/api/search",
+                    f"{self.config.base_url}/api/search",
                     json=request_body,
                 )
                 response.raise_for_status()
@@ -164,20 +175,21 @@ class SDESearchTool(BaseTool[SDESearchToolInputSchema, SDESearchToolOutputSchema
 
             documents.append(
                 SDEDocument(
+                    query=params.query,
                     title=title,
-                    url=url,
-                    snippet=snippet,
+                    content=snippet,
                     score=score,
-                    division=division,
-                    doc_type=doc_type,
+                    url=url,
+                    division=NASASMDDivision(division) if division else None,
+                    doc_type=SDEIndexedDocumentType(doc_type) if doc_type else None,
                     source=source,
                 )
             )
 
-        total_count = data.get("total_count", len(documents))
-
         return SDESearchToolOutputSchema(
-            documents=documents,
-            total_count=total_count,
-            query_used=params.query,
+            results=documents,
+            extra={
+                "total_count": data.get("total_count", 0),
+                "query_used": params.query,
+            },
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ requires-python = ">=3.12"
 dependencies = [
     "akd @ git+https://github.com/NASA-IMPACT/accelerated-discovery.git@develop",
     "openai-agents>=0.6.7",
+    "httpx>=0.27.0",
 ]
 
 [project.urls]

--- a/tests/tools/__init__.py
+++ b/tests/tools/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for akd_ext tools."""

--- a/tests/tools/test_sde_search.py
+++ b/tests/tools/test_sde_search.py
@@ -1,0 +1,145 @@
+"""Tests for the SDE Search Tool."""
+
+import pytest
+
+from akd_ext.structures import SDEIndexedDocumentType, NASASMDDivision, TextSearchType
+from akd_ext.tools import SDESearchTool, SDESearchToolInputSchema, SDESearchToolConfig
+
+
+@pytest.mark.integration
+async def test_sde_search_basic():
+    """Test basic SDE search functionality."""
+    tool = SDESearchTool()
+
+    # Perform a simple search
+    result = await tool.arun(
+        SDESearchToolInputSchema(
+            query="climate change",
+            limit=5,
+        )
+    )
+
+    # Verify response structure
+    assert result.documents is not None
+    assert isinstance(result.documents, list)
+    assert len(result.documents) > 0 and len(result.documents) <= 5
+    assert result.query_used == "climate change"
+
+    # If results are returned, verify document structure
+
+    print(f"Total results found: {result.total_count}")
+
+    for doc in result.documents:
+        assert doc.title is not None
+        assert doc.url is not None
+        assert doc.snippet is not None
+        assert isinstance(doc.score, float)
+
+        print(f"title: {doc.title}")
+        print(f"url: {doc.url}")
+        print(f"snippet: {doc.snippet[:100]}...")  # Print first 100 chars of snippet
+        print(f"score: {doc.score}")
+
+
+@pytest.mark.integration
+async def test_sde_search_with_division_filter():
+    """Test SDE search with division filter."""
+    config = SDESearchToolConfig(
+        division=NASASMDDivision.EARTH_SCIENCE,
+    )
+    tool = SDESearchTool(config=config)
+
+    result = await tool.arun(
+        SDESearchToolInputSchema(
+            query="climate change",
+            limit=5,
+        )
+    )
+
+    assert result.documents is not None
+    for doc in result.documents:
+        print(f"Document division: {doc.division}")
+        assert doc.division == NASASMDDivision.EARTH_SCIENCE.value
+
+    assert len(result.documents) <= 5
+
+    # If results exist, optionally verify division
+    print(f"Total results found: {result.total_count}")
+    if result.documents:
+        print(f"Found {len(result.documents)} results for Earth Science division")
+
+
+@pytest.mark.integration
+async def test_sde_search_with_doc_type_filter():
+    """Test SDE search with document type filter."""
+    tool = SDESearchTool()
+
+    result = await tool.arun(
+        SDESearchToolInputSchema(
+            query="satellite data",
+            limit=5,
+            doc_type=SDEIndexedDocumentType.DATA,
+        )
+    )
+
+    assert result.documents is not None
+    for doc in result.documents:
+        print(f"Document type: {doc.doc_type}")
+        assert doc.doc_type == SDEIndexedDocumentType.DATA.value
+    assert len(result.documents) > 0
+
+
+@pytest.mark.integration
+async def test_sde_search_types():
+    """Test different search types."""
+    config = SDESearchToolConfig(
+        search_type=TextSearchType.HYBRID,
+    )
+    tool = SDESearchTool(config=config)
+
+    # Test hybrid search
+    result_hybrid = await tool.arun(
+        SDESearchToolInputSchema(
+            query="Mars rover",
+            limit=3,
+        )
+    )
+    assert result_hybrid.documents is not None
+    assert len(result_hybrid.documents) > 0
+
+
+@pytest.mark.integration
+async def test_sde_search_obscure_text():
+    """Test SDE search that may return no results."""
+    tool = SDESearchTool()
+
+    # Use a very specific/obscure query
+    result = await tool.arun(
+        SDESearchToolInputSchema(
+            query="xyzabc123nonexistentquery456",
+            limit=5,
+        )
+    )
+
+    assert result.documents is not None
+    assert isinstance(result.documents, list)
+    print(f"Number of documents returned: {len(result.documents)}")
+    print(result.documents)
+    assert result.total_count >= 0
+
+
+@pytest.mark.integration
+async def test_sde_search_limit_parameter():
+    """Test that limit parameter is respected."""
+    tool = SDESearchTool()
+
+    result = await tool.arun(
+        SDESearchToolInputSchema(
+            query="NASA",
+            limit=3,
+        )
+    )
+
+    assert result.documents is not None
+    print(f"Number of documents returned: {len(result.documents)}")
+    assert len(result.documents) <= 3

--- a/tests/tools/test_sde_search.py
+++ b/tests/tools/test_sde_search.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from akd_ext.structures import SDEIndexedDocumentType, NASASMDDivision, TextSearchType
+from akd_ext.structures import SDEIndexedDocumentType, NASASMDDivision
 from akd_ext.tools import SDESearchTool, SDESearchToolInputSchema, SDESearchToolConfig
 
 
@@ -20,24 +20,22 @@ async def test_sde_search_basic():
     )
 
     # Verify response structure
-    assert result.documents is not None
-    assert isinstance(result.documents, list)
-    assert len(result.documents) > 0 and len(result.documents) <= 5
-    assert result.query_used == "climate change"
+    assert result.results is not None
+    assert isinstance(result.results, list)
+    assert len(result.results) > 0 and len(result.results) <= 5
 
     # If results are returned, verify document structure
 
-    print(f"Total results found: {result.total_count}")
-
-    for doc in result.documents:
+    for doc in result.results:
         assert doc.title is not None
         assert doc.url is not None
-        assert doc.snippet is not None
+        assert doc.content is not None
         assert isinstance(doc.score, float)
+        assert doc.query == "climate change"
 
         print(f"title: {doc.title}")
         print(f"url: {doc.url}")
-        print(f"snippet: {doc.snippet[:100]}...")  # Print first 100 chars of snippet
+        print(f"content: {doc.content[:100]}...")  # Print first 100 chars of content
         print(f"score: {doc.score}")
 
 
@@ -56,17 +54,16 @@ async def test_sde_search_with_division_filter():
         )
     )
 
-    assert result.documents is not None
-    for doc in result.documents:
+    assert result.results is not None
+    for doc in result.results:
         print(f"Document division: {doc.division}")
         assert doc.division == NASASMDDivision.EARTH_SCIENCE.value
 
-    assert len(result.documents) <= 5
+    assert len(result.results) <= 5
 
     # If results exist, optionally verify division
-    print(f"Total results found: {result.total_count}")
-    if result.documents:
-        print(f"Found {len(result.documents)} results for Earth Science division")
+    if result.results:
+        print(f"Found {len(result.results)} results for Earth Science division")
 
 
 @pytest.mark.integration
@@ -82,18 +79,18 @@ async def test_sde_search_with_doc_type_filter():
         )
     )
 
-    assert result.documents is not None
-    for doc in result.documents:
+    assert result.results is not None
+    for doc in result.results:
         print(f"Document type: {doc.doc_type}")
         assert doc.doc_type == SDEIndexedDocumentType.DATA.value
-    assert len(result.documents) > 0
+    assert len(result.results) > 0
 
 
 @pytest.mark.integration
 async def test_sde_search_types():
     """Test different search types."""
     config = SDESearchToolConfig(
-        search_type=TextSearchType.HYBRID,
+        search_type="hybrid",
     )
     tool = SDESearchTool(config=config)
 
@@ -104,8 +101,8 @@ async def test_sde_search_types():
             limit=3,
         )
     )
-    assert result_hybrid.documents is not None
-    assert len(result_hybrid.documents) > 0
+    assert result_hybrid.results is not None
+    assert len(result_hybrid.results) > 0
 
 
 @pytest.mark.integration
@@ -121,11 +118,10 @@ async def test_sde_search_obscure_text():
         )
     )
 
-    assert result.documents is not None
-    assert isinstance(result.documents, list)
-    print(f"Number of documents returned: {len(result.documents)}")
-    print(result.documents)
-    assert result.total_count >= 0
+    assert result.results is not None
+    assert isinstance(result.results, list)
+    print(f"Number of results returned: {len(result.results)}")
+    print(result.results)
 
 
 @pytest.mark.integration
@@ -140,6 +136,6 @@ async def test_sde_search_limit_parameter():
         )
     )
 
-    assert result.documents is not None
-    print(f"Number of documents returned: {len(result.documents)}")
-    assert len(result.documents) <= 3
+    assert result.results is not None
+    print(f"Number of results returned: {len(result.results)}")
+    assert len(result.results) <= 3

--- a/tests/tools/test_sde_search.py
+++ b/tests/tools/test_sde_search.py
@@ -1,7 +1,7 @@
 """Tests for the SDE Search Tool."""
 
 import pytest
-
+import httpx
 from akd_ext.structures import SDEIndexedDocumentType, NASASMDDivision
 from akd_ext.tools import SDESearchTool, SDESearchToolInputSchema, SDESearchToolConfig
 
@@ -139,3 +139,170 @@ async def test_sde_search_limit_parameter():
     assert result.results is not None
     print(f"Number of results returned: {len(result.results)}")
     assert len(result.results) <= 3
+
+
+@pytest.mark.integration
+async def test_sde_search_url_validation():
+    """Test that URL validation filters out 404s and other inaccessible URLs."""
+    # Enable URL validation
+    config = SDESearchToolConfig(
+        validate_urls=True,
+        url_check_timeout=10.0,  # Longer timeout for this test
+    )
+    tool = SDESearchTool(config=config)
+
+    result = await tool.arun(
+        SDESearchToolInputSchema(
+            query="Mars rover",
+            limit=20,  # Request more results to increase chance of finding valid URLs
+        )
+    )
+
+    assert result.results is not None
+    print(f"Number of results after URL validation: {len(result.results)}")
+
+    # Verify all returned URLs are accessible (no 404s)
+
+    for doc in result.results:
+        assert doc.url, f"Document '{doc.title}' has empty URL"
+        print(f"Checking URL: {doc.url}")
+
+        # Verify the URL is accessible
+        async with httpx.AsyncClient(timeout=10.0, follow_redirects=True) as client:
+            try:
+                response = await client.head(doc.url)
+                print(f"  Status: {response.status_code}")
+                # All returned documents should have status < 400
+                assert response.status_code < 400, f"URL {doc.url} returned status {response.status_code}"
+            except httpx.HTTPError as e:
+                pytest.fail(f"URL {doc.url} failed validation but was not filtered: {e}")
+
+    # Verify extra metadata includes filtered_count
+    # filtered_count is the number of results after URL validation AND truncation to limit
+    assert result.extra is not None
+    assert "filtered_count" in result.extra
+    assert result.extra["filtered_count"] == len(result.results)
+    print(f"Total count from API: {result.extra.get('total_count')}")
+    print(f"Filtered count (after validation & truncation): {result.extra.get('filtered_count')}")
+
+
+@pytest.mark.integration
+async def test_sde_search_url_validation_disabled():
+    """Test that URL validation can be disabled."""
+    # Disable URL validation
+    config = SDESearchToolConfig(
+        validate_urls=False,
+    )
+    tool = SDESearchTool(config=config)
+
+    result = await tool.arun(
+        SDESearchToolInputSchema(
+            query="climate change",
+            limit=5,
+        )
+    )
+
+    assert result.results is not None
+    # When validation is disabled, filtered_count should be None (no filtering/truncation tracking)
+    assert result.extra is not None
+    assert result.extra.get("filtered_count") is None
+
+
+@pytest.mark.integration
+async def test_sde_search_result_multiplier():
+    """Test that result_multiplier fetches more results for filtering."""
+    # Use a higher multiplier to fetch more results
+    config = SDESearchToolConfig(
+        validate_urls=True,
+        result_multiplier=3.0,
+        url_check_timeout=10.0,
+    )
+    tool = SDESearchTool(config=config)
+
+    limit = 5
+    result = await tool.arun(
+        SDESearchToolInputSchema(
+            query="Mars",
+            limit=limit,
+        )
+    )
+
+    assert result.results is not None
+    assert result.extra is not None
+
+    # Verify metadata
+    assert result.extra.get("requested_limit") == limit
+    assert result.extra.get("filtered_count") is not None
+
+    # filtered_count should equal len(results) since it's the count after truncation to limit
+    assert result.extra.get("filtered_count") == len(result.results)
+
+    # Results should not exceed requested limit
+    assert len(result.results) <= limit
+
+    print(f"Requested limit: {limit}")
+    print(f"Final result count: {len(result.results)}")
+    print(f"Filtered count (after validation & truncation): {result.extra.get('filtered_count')}")
+    print(f"Total from API: {result.extra.get('total_count')}")
+
+
+@pytest.mark.integration
+async def test_sde_search_result_multiplier_respects_api_max():
+    """Test that result_multiplier respects the API maximum of 100."""
+    # Set a high multiplier that would exceed 100
+    config = SDESearchToolConfig(
+        validate_urls=True,
+        result_multiplier=10.0,  # Max allowed
+        url_check_timeout=10.0,
+    )
+    tool = SDESearchTool(config=config)
+
+    # Request 20 results, which with 10x multiplier would be 200, but should cap at 100
+    limit = 20
+    result = await tool.arun(
+        SDESearchToolInputSchema(
+            query="NASA",
+            limit=limit,
+        )
+    )
+
+    assert result.results is not None
+    assert len(result.results) <= limit
+
+    # The tool should have fetched at most 100 from the API (not 200)
+    # filtered_count is the number of results after validation AND truncation to the requested limit
+    if result.extra and result.extra.get("filtered_count"):
+        # Since we requested 20 results, filtered_count should equal min(validated_results, 20)
+        assert result.extra.get("filtered_count") == len(result.results)
+        assert result.extra.get("filtered_count") <= limit
+        print(f"Filtered count (after validation & truncation): {result.extra.get('filtered_count')}")
+        print(f"Requested limit: {limit}")
+        print(f"Result count: {len(result.results)}")
+
+
+@pytest.mark.integration
+async def test_sde_search_result_multiplier_disabled():
+    """Test that result_multiplier is not used when validation is disabled."""
+    # Disable URL validation - multiplier should not apply
+    config = SDESearchToolConfig(
+        validate_urls=False,
+        result_multiplier=5.0,
+    )
+    tool = SDESearchTool(config=config)
+
+    limit = 10
+    result = await tool.arun(
+        SDESearchToolInputSchema(
+            query="climate change",
+            limit=limit,
+        )
+    )
+
+    assert result.results is not None
+    # When validation is disabled, should fetch exactly the limit (not limit * multiplier)
+    # filtered_count should be None since validation is disabled
+    assert result.extra is not None
+    assert result.extra.get("filtered_count") is None
+    assert result.extra.get("requested_limit") == limit
+    # Results should equal the requested limit (no over-fetching when validation is off)
+    assert len(result.results) <= limit


### PR DESCRIPTION
# Example usage

## Basic Usage

```python
from akd_ext.tools import SDESearchTool, SDESearchToolInputSchema

# Create tool instance
tool = SDESearchTool()

# Perform a simple search
output = await tool.arun(
    SDESearchToolInputSchema(
        query="climate change",
        limit=5,
    )
)

# Access results
print(f"Total results found: {output.extra['total_count']}")

for doc in output.results:
    print(f"title: {doc.title}")
    print(f"url: {doc.url}")
    print(f"score: {doc.score}")
```

## Filtering by Division

```python
from akd_ext.tools import SDESearchTool, SDESearchToolInputSchema, SDESearchToolConfig
from akd_ext.structures import NASASMDDivision

# Configure tool with division filter
config = SDESearchToolConfig(
    division=NASASMDDivision.EARTH_SCIENCE,
)
tool = SDESearchTool(config=config)

result = await tool.arun(
    SDESearchToolInputSchema(
        query="climate change",
        limit=5,
    )
)
```

## Filtering by Document Type

```python
from akd_ext.structures import SDEIndexedDocumentType

tool = SDESearchTool()

result = await tool.arun(
    SDESearchToolInputSchema(
        query="satellite data",
        limit=5,
        doc_type=DocumentType.DATA,
    )
)
```

## Search Types

```python
from akd_ext.structures import SearchType

# Hybrid search (default - combines vector + keyword)
config = SDESearchToolConfig(
    search_type=SearchType.VECTOR,
)
tool = SDESearchTool(config=config)
result = await tool.arun(
    SDESearchToolInputSchema(
        query="Mars rover",
        limit=3,
    )
)
```

