### PR TITLE
set retry to false. also add in try catch to handle extra issues

### DIFF
--- a/akd_ext/tools/code_search/repository_search.py
+++ b/akd_ext/tools/code_search/repository_search.py
@@ -118,7 +118,7 @@ class RepositorySearchTool(SDECodeSearchTool):
         owner, repo = path_parts[0], path_parts[1]
         repo_name = f"{owner}/{repo}"
         repository_metadata: RepositoryMetadata = await fetch_github_metadata(repo_name, self.config.access_token)
-        reliability_score: float = calculate_reliability_score(repository_metadata)
+        reliability_score: float | None = calculate_reliability_score(repository_metadata)
         return RepositorySearchResultItem(
             **{
                 **repository_item.model_dump(),

--- a/akd_ext/tools/code_search/repository_search.py
+++ b/akd_ext/tools/code_search/repository_search.py
@@ -21,8 +21,9 @@ class RepositorySearchResultItem(SearchResultItem):
     Search result item with added github repository metadata and computed reliability score.
     """
 
-    reliability_score: float = Field(
-        default=1.0, description="Computed reliability score based on github repository metadata."
+    reliability_score: float | None = Field(
+        default=None,
+        description="Computed reliability score based on github repository metadata. If none, treat it neutrally as if there is no reliability score.",
     )
     repository_metadata: RepositoryMetadata = Field(
         default_factory=RepositoryMetadata,

--- a/akd_ext/tools/code_search/utils.py
+++ b/akd_ext/tools/code_search/utils.py
@@ -52,7 +52,7 @@ async def fetch_github_metadata(repo_name: str, access_token: str | None = None)
     return repository_metadata
 
 
-def calculate_reliability_score(repository_metadata: RepositoryMetadata) -> float:
+def calculate_reliability_score(repository_metadata: RepositoryMetadata) -> float | None:
     """
     Calculate a comprehensive reliability score (0-100) for a repository.
 
@@ -71,6 +71,10 @@ def calculate_reliability_score(repository_metadata: RepositoryMetadata) -> floa
     Returns:
         float: reliability score between 0 and 100
     """
+    # if repository_metadata is default return None
+    if repository_metadata == RepositoryMetadata():
+        return None
+
     now = datetime.now(timezone.utc)
 
     # Parse dates - return 0 if essential data is missing

--- a/akd_ext/tools/code_search/utils.py
+++ b/akd_ext/tools/code_search/utils.py
@@ -33,17 +33,22 @@ async def fetch_github_metadata(repo_name: str, access_token: str | None = None)
     auth = None
     if access_token:
         auth = Auth.Token(access_token)
-    with Github(auth=auth) as g:
-        repo = g.get_repo(repo_name)
-        repository_metadata.stars = repo.stargazers_count
-        repository_metadata.forks = repo.forks_count
-        repository_metadata.watchers = repo.subscribers_count
-        repository_metadata.last_updated = repo.pushed_at.isoformat() if repo.pushed_at else ""
-        repository_metadata.created_at = repo.created_at.isoformat() if repo.created_at else ""
-        repository_metadata.open_issues = repo.get_issues(state="open").totalCount
-        repository_metadata.pulls = repo.get_pulls(state="open", sort="created", base="master").totalCount
-        repository_metadata.closed_pulls = repo.get_pulls(state="closed", sort="created", base="master").totalCount
-        repository_metadata.first_commit_date = None  # The original comde provided also fell back to created_at if first_commit_date was not available. And it was set to None by default.
+    try:
+        with Github(auth=auth, retry=None) as g:
+            repo = g.get_repo(repo_name)
+            repository_metadata.stars = repo.stargazers_count
+            repository_metadata.forks = repo.forks_count
+            repository_metadata.watchers = repo.subscribers_count
+            repository_metadata.last_updated = repo.pushed_at.isoformat() if repo.pushed_at else ""
+            repository_metadata.created_at = repo.created_at.isoformat() if repo.created_at else ""
+            repository_metadata.open_issues = repo.get_issues(state="open").totalCount
+            repository_metadata.pulls = repo.get_pulls(state="open", sort="created", base="master").totalCount
+            repository_metadata.closed_pulls = repo.get_pulls(state="closed", sort="created", base="master").totalCount
+            repository_metadata.first_commit_date = None  # The original code provided also fell back to created_at if first_commit_date was not available. And it was set to None by default.
+    except Exception as e:
+        logger.error(f"Error fetching metadata for {repo_name}: {e}")
+        return repository_metadata
+
     return repository_metadata
 
 

--- a/akd_ext/tools/code_search/utils.py
+++ b/akd_ext/tools/code_search/utils.py
@@ -1,5 +1,5 @@
 from github import Github, Auth
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, computed_field
 from datetime import datetime, timezone
 import math
 from functools import lru_cache
@@ -22,6 +22,14 @@ class RepositoryMetadata(BaseModel):
     open_issues: int = Field(default=0, description="Number of open issues on the repository.")
     pulls: int = Field(default=0, description="Number of open pull requests on the repository.")
     closed_pulls: int = Field(default=0, description="Number of closed pull requests on the repository.")
+
+    @computed_field
+    @property
+    def is_null_metadata(self) -> bool:
+        return all(
+            getattr(self, field_name) == field_info.default
+            for field_name, field_info in RepositoryMetadata.model_fields.items()
+        )
 
 
 @lru_cache(maxsize=128)
@@ -69,10 +77,10 @@ def calculate_reliability_score(repository_metadata: RepositoryMetadata) -> floa
         repository_metadata: RepositoryMetadata with stars, forks, created_at, last_updated, first_commit_date
 
     Returns:
-        float: reliability score between 0 and 100
+        float: reliability score between 0 and 100 or None if metadata is null
     """
-    # if repository_metadata is default return None
-    if repository_metadata == RepositoryMetadata():
+
+    if repository_metadata.is_null_metadata:
         return None
 
     now = datetime.now(timezone.utc)
@@ -131,9 +139,11 @@ def calculate_reliability_score(repository_metadata: RepositoryMetadata) -> floa
 
 if __name__ == "__main__":
     import asyncio
+    from dotenv import load_dotenv
     import os
     import sys
 
+    load_dotenv()
     access_token = os.getenv("GITHUB_ACCESS_TOKEN", None)
     repo = "NASA-IMPACT/veda-config-ghg"
     if len(sys.argv) > 1:


### PR DESCRIPTION
# Issue:
Exponential backoff policy of PyGithub causing MCP cloud to fail.

# resolution:
The rate limit is minimal for github without access token. So, instead of waiting for the response via exponential backoff, cutting off the request and sending back default values.

To elobrate, the PyGithub has an elaborate retry mechanism and timeouts built out of the box. As the default timeout is 15 seconds, i just left that as it is. I've just changed the retry to be none.

The alternative method would be to not have a concesion on DEFAULT_BACKOFF_MAX (120 current) and DEFAULT_RETRY_AFTER_MAX(21600 current) to something smaller.
