### PR TITLE
feat: Add streaming support to OpenAIBaseAgent

### DIFF
--- a/akd_ext/agents/_base.py
+++ b/akd_ext/agents/_base.py
@@ -392,7 +392,7 @@ class FreeFormOutput(OutputSchema):
     response: str = Field(..., description="Free-form text response from agent")
 
 
-class FreeFormOpenAIBaseAgent[InSchema: InputSchema](OpenAIBaseAgent[InSchema, FreeFormOutput, StreamingMixin]):
+class FreeFormOpenAIBaseAgent[InSchema: InputSchema](OpenAIBaseAgent[InSchema, FreeFormOutput]):
     """Base for OpenAI agents returning free-form text (no structured output_type).
 
     Use when the agent should return unstructured text that gets wrapped

--- a/akd_ext/agents/_base.py
+++ b/akd_ext/agents/_base.py
@@ -36,8 +36,13 @@ from akd._base import (
     CompletedEventData,
     FailedEvent,
     FailedEventData,
+    HumanResponseEvent,
+    HumanResponseEventData,
+    HumanInputRequiredEvent,
+    HumanInputRequiredEventData,
 )
 from akd.agents._base import BaseAgent, BaseAgentConfig
+from akd.tools.human import HumanToolInput
 
 
 class OpenAIBaseAgentConfig(BaseAgentConfig):
@@ -562,6 +567,24 @@ class FreeFormOpenAIBaseAgent[InSchema: InputSchema](OpenAIBaseAgent[InSchema, F
         if "run_id" not in run_context:
             run_context["run_id"] = uuid.uuid4().hex[:8]
 
+        if run_context.get("human_response"):
+            content = run_context.get("human_response").content
+            self._memory.append(
+                {
+                    "role": "user",
+                    "content": content if isinstance(content, str) else json.dumps(content),
+                },
+            )
+            yield HumanResponseEvent(
+                source=class_name,
+                message="Resumed with human input",
+                data=HumanResponseEventData(
+                    tool_call_id=run_context.human_response.tool_call_id,
+                    response=content,
+                ),
+                run_context=run_context,
+            )
+
         yield StartingEvent(
             source=class_name,
             message=f"Starting {class_name}",
@@ -619,6 +642,38 @@ class FreeFormOpenAIBaseAgent[InSchema: InputSchema](OpenAIBaseAgent[InSchema, F
                         ),
                         run_context=run_context,
                     )
+
+                    if chunk["tool_name"] == "ask_human":
+                        # Store messages in run_context for resumption
+                        run_context["messages"] = list(self._memory) if self._memory else []
+                        run_context["messages"].append(
+                            {
+                                "role": "assistant",
+                                "content": None,
+                                "tool_calls": {
+                                    "id": chunk.get("tool_call_id") or uuid.uuid4().hex[:8],
+                                    "type": "function",
+                                    "function": {"name": chunk["tool_name"], "arguments": tool_args},
+                                },
+                            },
+                        )
+
+                        # Yield HUMAN_INPUT_REQUIRED with full state for resumption
+                        yield HumanInputRequiredEvent(
+                            source=class_name,
+                            message=f"Human input required: {tool_args.get('question', 'Input needed')}",
+                            data=HumanInputRequiredEventData(
+                                human_input=HumanToolInput(
+                                    question=tool_args.get("question", "Input needed"),
+                                ),
+                                tool_call_id=chunk.get("tool_call_id") or uuid.uuid4().hex[:8],
+                                tool_name=chunk["tool_name"],
+                                arguments=tool_args,
+                            ),
+                            run_context=run_context,
+                        )
+                        # End generator gracefully - caller will resume with fresh astream() call
+                        return
 
                 elif chunk["type"] == StreamEventType.TOOL_RESULT:
                     yield ToolResultEvent(

--- a/akd_ext/agents/_base.py
+++ b/akd_ext/agents/_base.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import uuid
 from collections.abc import AsyncIterator
 from typing import Any
@@ -15,7 +16,6 @@ from openai.types.shared.reasoning import Reasoning
 from pydantic import Field
 
 from akd._base import (
-    RunContext,
     InputSchema,
     OutputSchema,
     StartingEvent,
@@ -50,6 +50,10 @@ class OpenAIBaseAgentConfig(BaseAgentConfig):
     Defaults to `stateless=False` (stateful) for multi-turn conversations.
     """
 
+    model_name: str = Field(
+        default="gpt-5-nano",
+        description="Model name for the agent.",
+    )
     stateless: bool = Field(
         default=False,
         description="Whether to maintain conversation history. False = stateful (default for OpenAI agents).",
@@ -164,7 +168,7 @@ class OpenAIBaseAgent[InSchema: InputSchema, OutSchema: OutputSchema](BaseAgent,
         return Agent(
             name=self.__class__.__name__,
             instructions=self.config.system_prompt,
-            model=self.config.model_name or "gpt-4o",
+            model=self.config.model_name or "gpt-5-nano",
             tools=self.config.tools,
             output_type=self.output_schema,
             model_settings=self.config.model_settings,
@@ -296,6 +300,13 @@ class OpenAIBaseAgent[InSchema: InputSchema, OutSchema: OutputSchema](BaseAgent,
         class_name = self.__class__.__name__
         response_model = self.output_schema
         run_context = context.copy() if context else {}
+
+        if self.config.stateless:
+            self.reset_memory()
+
+        # Add user input to memory
+        self._memory.append({"role": "user", "content": params.model_dump_json()})
+
         if "run_id" not in run_context:
             run_context["run_id"] = uuid.uuid4().hex[:8]
 
@@ -307,11 +318,6 @@ class OpenAIBaseAgent[InSchema: InputSchema, OutSchema: OutputSchema](BaseAgent,
         )
 
         try:
-            messages = [] if self.config.stateless else self._memory.copy()
-
-            if params:
-                messages.append({"role": "user", "content": params.model_dump_json(exclude={"type"})})
-
             yield RunningEvent(
                 source=class_name,
                 message=f"Running {class_name}",
@@ -320,7 +326,7 @@ class OpenAIBaseAgent[InSchema: InputSchema, OutSchema: OutputSchema](BaseAgent,
             )
 
             final_output = None
-            async for chunk in self._stream_llm_response(messages, token_batch_size=token_batch_size):
+            async for chunk in self._stream_llm_response(messages=self._memory, token_batch_size=token_batch_size):
                 if chunk["type"] == StreamEventType.STREAMING:
                     yield StreamingTokenEvent(
                         source=class_name,
@@ -340,6 +346,14 @@ class OpenAIBaseAgent[InSchema: InputSchema, OutSchema: OutputSchema](BaseAgent,
                     )
 
                 elif chunk["type"] == StreamEventType.TOOL_CALLING:
+                    # Parse tool_input if it's a JSON string
+                    tool_args = chunk["tool_input"]
+                    if isinstance(tool_args, str):
+                        try:
+                            tool_args = json.loads(tool_args)
+                        except json.JSONDecodeError:
+                            tool_args = {}
+
                     yield ToolCallingEvent(
                         source=class_name,
                         message=f"Calling tool: {chunk['tool_name']}",
@@ -348,7 +362,7 @@ class OpenAIBaseAgent[InSchema: InputSchema, OutSchema: OutputSchema](BaseAgent,
                                 tool_call_id=chunk.get("tool_call_id")
                                 or uuid.uuid4().hex[:8],  # does chunk have a tool call id??
                                 tool_name=chunk["tool_name"],
-                                arguments=chunk["tool_input"],
+                                arguments=tool_args,
                             )
                         ),
                         run_context=run_context,
@@ -358,8 +372,8 @@ class OpenAIBaseAgent[InSchema: InputSchema, OutSchema: OutputSchema](BaseAgent,
                     yield ToolResultEvent(
                         source=class_name,
                         message=f"Tool result: {chunk['tool_name']}",
-                        result=ToolResultEventData(
-                            tool_result=ToolResult(
+                        data=ToolResultEventData(
+                            result=ToolResult(
                                 tool_call_id=chunk.get("tool_call_id") or uuid.uuid4().hex[:8],
                                 tool_name=chunk["tool_name"],
                                 content=chunk["tool_output"],
@@ -375,8 +389,7 @@ class OpenAIBaseAgent[InSchema: InputSchema, OutSchema: OutputSchema](BaseAgent,
                 raise ValueError("No output received from LLM")
 
             if not self.config.stateless:
-                messages.append({"role": "assistant", "content": final_output.model_dump_json(exclude={"type"})})
-                self._memory = messages
+                self._memory.append({"role": "assistant", "content": final_output.model_dump_json(exclude={"type"})})
 
             # final_output may already be parsed model or JSON string
             if isinstance(final_output, response_model):
@@ -448,12 +461,106 @@ class FreeFormOpenAIBaseAgent[InSchema: InputSchema](OpenAIBaseAgent[InSchema, F
         response_text = str(result.final_output)
         return self.output_schema(response=response_text)
 
-    async def _astream(self, params: InSchema, **kwargs) -> AsyncIterator[StreamEvent]:
-        """Stream agent response and yield events."""
+    async def _stream_llm_response(
+        self,
+        messages: list[dict[str, Any]],
+        token_batch_size: int = 10,
+    ) -> AsyncIterator[dict[str, Any]]:
+        """Stream using Runner.run_streamed() for free-form text output.
+
+        Unlike the parent class, this collects raw text and wraps it in
+        FreeFormOutput since free-form agents don't have an output_type.
+        """
+
+        token_buffer = ""
+        full_response = ""  # Collect complete response for FreeFormOutput
+
+        stream = Runner.run_streamed(
+            self._agent,
+            input=messages,
+            run_config=self.config.run_config,
+            max_turns=20,
+        )
+
+        async for event in stream.stream_events():
+            if isinstance(event, RawResponsesStreamEvent):
+                event_type = getattr(event.data, "type", "")
+
+                if event_type == "response.output_text.delta":
+                    delta = getattr(event.data, "delta", "") or ""
+                    token_buffer += delta
+                    full_response += delta  # Accumulate for final output
+                    if len(token_buffer) >= token_batch_size:
+                        yield {"type": StreamEventType.STREAMING, "token": token_buffer}
+                        token_buffer = ""
+
+                elif event_type == "response.output_text.done":
+                    if token_buffer:
+                        yield {"type": StreamEventType.STREAMING, "token": token_buffer}
+                        token_buffer = ""
+
+                elif "reasoning" in event_type:
+                    content = getattr(event.data, "content", "") or getattr(event.data, "delta", "") or ""
+                    if content:
+                        yield {"type": StreamEventType.THINKING, "content": content}
+
+            elif isinstance(event, RunItemStreamEvent):
+                if event.name == "tool_called":
+                    raw_item = getattr(event.item, "raw_item", None)
+                    if raw_item:
+                        tool_name = getattr(raw_item, "name", "")
+                        tool_input = getattr(raw_item, "arguments", "{}")
+                        tool_output = getattr(raw_item, "output", None)
+
+                        yield {
+                            "type": StreamEventType.TOOL_CALLING,
+                            "tool_name": tool_name,
+                            "tool_input": tool_input,
+                        }
+
+                        if tool_output:
+                            yield {
+                                "type": StreamEventType.TOOL_RESULT,
+                                "tool_name": tool_name,
+                                "tool_output": tool_output,
+                            }
+
+                elif event.name == "message_output_created":
+                    if token_buffer:
+                        yield {"type": StreamEventType.STREAMING, "token": token_buffer}
+                        token_buffer = ""
+
+        # For free-form agents: wrap raw text in FreeFormOutput
+        # Use collected full_response, or fall back to stream.final_output
+        if full_response:
+            final_output = self.output_schema(response=full_response)
+        else:
+            # Fallback: try to get from stream final_output (string)
+            raw_output = str(stream.final_output) if stream.final_output else ""
+            final_output = self.output_schema(response=raw_output)
+
+        yield {"type": StreamEventType.COMPLETED, "output": final_output}
+
+    async def _astream(
+        self,
+        params: InSchema,
+        context: dict[str, Any] | None = None,
+        token_batch_size: int = 10,
+        **kwargs: Any,
+    ) -> AsyncIterator[StreamEvent]:
+        """Stream execution with akd StreamEvent format."""
+
         class_name = self.__class__.__name__
-        run_context = kwargs.get("run_context")
-        if run_context is None:
-            run_context = RunContext()
+        run_context = context.copy() if context else {}
+
+        if self.config.stateless:
+            self.reset_memory()
+
+        # Add user input to memory
+        self._memory.append({"role": "user", "content": params.model_dump_json()})
+
+        if "run_id" not in run_context:
+            run_context["run_id"] = uuid.uuid4().hex[:8]
 
         yield StartingEvent(
             source=class_name,
@@ -463,31 +570,86 @@ class FreeFormOpenAIBaseAgent[InSchema: InputSchema](OpenAIBaseAgent[InSchema, F
         )
 
         try:
-            async with self.memory.asession(
-                stateless=self.stateless,
+            yield RunningEvent(
+                source=class_name,
+                message=f"Running {class_name}",
+                data=RunningEventData(),
                 run_context=run_context,
-                enable_trimming=self.enable_trimming,
-                model_name=self.model_name,
-                max_tokens=self.max_tokens,
-                trim_ratio=self.trim_ratio,
-            ) as messages:
-                if params:
-                    messages.append({"role": "user", "content": params.model_dump_json(exclude={"type"})})
+            )
 
-                yield RunningEvent(
-                    source=class_name,
-                    message=f"Running {class_name}",
-                    data=RunningEventData(),
-                    run_context=run_context,
-                )
+            final_output = None
+            async for chunk in self._stream_llm_response(messages=self._memory, token_batch_size=token_batch_size):
+                if chunk["type"] == StreamEventType.STREAMING:
+                    yield StreamingTokenEvent(
+                        source=class_name,
+                        message=f"Streaming {class_name}",
+                        data=StreamingEventData(token=chunk["token"]),
+                        run_context=run_context,
+                    )
 
-                output: FreeFormOutput = await self._arun(params, **kwargs)
-                yield CompletedEvent(
-                    source=class_name,
-                    message=f"Completed {class_name}",
-                    data=CompletedEventData[self.output_schema](output=output),
-                    run_context=run_context,
-                )
+                elif chunk["type"] == StreamEventType.THINKING:
+                    yield ThinkingEvent(
+                        source=class_name,
+                        message="Reasoning...",
+                        data=ThinkingEventData(
+                            thinking_content=chunk["content"]
+                        ),  # check if reflection prompt is used and add reflection_content
+                        run_context=run_context,
+                    )
+
+                elif chunk["type"] == StreamEventType.TOOL_CALLING:
+                    # Parse tool_input if it's a JSON string
+                    tool_args = chunk["tool_input"]
+                    if isinstance(tool_args, str):
+                        try:
+                            tool_args = json.loads(tool_args)
+                        except json.JSONDecodeError:
+                            tool_args = {}
+
+                    yield ToolCallingEvent(
+                        source=class_name,
+                        message=f"Calling tool: {chunk['tool_name']}",
+                        data=ToolCallingEventData(
+                            tool_call=ToolCall(
+                                tool_call_id=chunk.get("tool_call_id")
+                                or uuid.uuid4().hex[:8],  # does chunk have a tool call id??
+                                tool_name=chunk["tool_name"],
+                                arguments=tool_args,
+                            )
+                        ),
+                        run_context=run_context,
+                    )
+
+                elif chunk["type"] == StreamEventType.TOOL_RESULT:
+                    yield ToolResultEvent(
+                        source=class_name,
+                        message=f"Tool result: {chunk['tool_name']}",
+                        data=ToolResultEventData(
+                            result=ToolResult(
+                                tool_call_id=chunk.get("tool_call_id") or uuid.uuid4().hex[:8],
+                                tool_name=chunk["tool_name"],
+                                content=chunk["tool_output"],
+                            )
+                        ),
+                        run_context=run_context,
+                    )
+
+                elif chunk["type"] == StreamEventType.COMPLETED:
+                    final_output = chunk["output"]
+
+            if final_output is None:
+                raise ValueError("No output received from LLM")
+
+            if not self.config.stateless:
+                self._memory.append({"role": "assistant", "content": final_output.model_dump_json(exclude={"type"})})
+
+            yield CompletedEvent(
+                source=class_name,
+                message=f"Completed {class_name}",
+                data=CompletedEventData[self.output_schema](output=final_output),
+                run_context=run_context,
+            )
+
         except Exception as e:
             yield FailedEvent(
                 source=class_name,

--- a/akd_ext/agents/_base.py
+++ b/akd_ext/agents/_base.py
@@ -1,8 +1,15 @@
 from __future__ import annotations
 
+import uuid
+from collections.abc import AsyncIterator
 from typing import Any
 
 from agents import Agent, ModelSettings, RunConfig, Runner, trace
+from agents.stream_events import (
+    RawResponsesStreamEvent,
+    RunItemStreamEvent,
+)
+from akd._base.streaming import StreamEvent, StreamEventType, StreamingMixin
 from openai.types.shared.reasoning import Reasoning
 from pydantic import Field
 
@@ -74,7 +81,9 @@ class OpenAIBaseAgentConfig(BaseAgentConfig):
         return RunConfig(trace_metadata=self.tracing_params or {})
 
 
-class OpenAIBaseAgent[InSchema: InputSchema, OutSchema: OutputSchema](BaseAgent):
+class OpenAIBaseAgent[InSchema: InputSchema, OutSchema: OutputSchema](
+    BaseAgent, StreamingMixin
+):
     """Base class for OpenAI Agents SDK based agents.
 
     Provides:
@@ -177,6 +186,174 @@ class OpenAIBaseAgent[InSchema: InputSchema, OutSchema: OutputSchema](BaseAgent)
         else:
             return self.output_schema.model_validate_json(str(final_output))
 
+    async def _stream_llm_response(
+        self,
+        messages: list[dict[str, Any]],
+        token_batch_size: int = 10,
+    ) -> AsyncIterator[dict[str, Any]]:
+        """Stream using Runner.run_streamed()."""
+        
+        token_buffer = ""
+        
+        stream = Runner.run_streamed(
+            self._agent,
+            input=messages,
+            run_config=self.config.run_config,
+        )
+        
+        async for event in stream.stream_events():
+            
+            if isinstance(event, RawResponsesStreamEvent):
+                event_type = getattr(event.data, "type", "")
+                
+                if event_type == "response.output_text.delta":
+                    delta = getattr(event.data, "delta", "") or ""
+                    token_buffer += delta
+                    if len(token_buffer) >= token_batch_size:
+                        yield {"type": StreamEventType.STREAMING, "token": token_buffer}
+                        token_buffer = ""
+
+                elif event_type == "response.output_text.done":
+                    if token_buffer:
+                        yield {"type": StreamEventType.STREAMING, "token": token_buffer}
+                        token_buffer = ""
+                
+                elif "reasoning" in event_type:
+                    content = getattr(event.data, "content", "") or getattr(event.data, "delta", "") or ""
+                    if content:
+                        yield {"type": StreamEventType.THINKING, "content": content}
+            
+            elif isinstance(event, RunItemStreamEvent):
+                
+                if event.name == "tool_called":
+                    raw_item = getattr(event.item, "raw_item", None)
+                    if raw_item:
+                        tool_name = getattr(raw_item, "name", "")
+                        tool_input = getattr(raw_item, "arguments", "{}")
+                        tool_output = getattr(raw_item, "output", None)
+                        
+                        yield {
+                            "type": StreamEventType.TOOL_CALLING,
+                            "tool_name": tool_name,
+                            "tool_input": tool_input,
+                        }
+                        
+                        if tool_output:
+                            yield {
+                                "type": StreamEventType.TOOL_RESULT,
+                                "tool_name": tool_name,
+                                "tool_output": tool_output,
+                            }
+                
+                elif event.name == "message_output_created":
+                    if token_buffer:
+                        yield {"type": StreamEventType.STREAMING, "token": token_buffer}
+                        token_buffer = ""
+        
+        final_output = stream.final_output_as(self.output_schema, raise_if_incorrect_type=False)
+        if final_output:
+            yield {"type": StreamEventType.COMPLETED, "output": final_output}
+
+
+    async def _astream(
+        self,
+        params: InSchema,
+        context: dict[str, Any] | None = None,
+        token_batch_size: int = 10,
+        **kwargs: Any,
+    ) -> AsyncIterator[StreamEvent]:
+        """Stream execution with akd StreamEvent format."""
+        
+        class_name = self.__class__.__name__
+        run_context = context.copy() if context else {}
+        if "run_id" not in run_context:
+            run_context["run_id"] = uuid.uuid4().hex[:8]
+
+        yield StreamEvent(
+            event_type=StreamEventType.STARTING,
+            source=class_name,
+            message=f"Starting {class_name}",
+            context=run_context,
+        )
+
+        try:
+            messages = [] if self.config.stateless else self._memory.copy()
+            
+            if params:
+                messages.append({"role": "user", "content": params.model_dump_json(exclude={"type"})})
+
+            yield StreamEvent(
+                event_type=StreamEventType.RUNNING,
+                source=class_name,
+                message=f"Running {class_name}",
+                context=run_context,
+            )
+
+            final_output = None
+            async for chunk in self._stream_llm_response(messages, token_batch_size=token_batch_size):
+                
+                if chunk["type"] == StreamEventType.STREAMING:
+                    yield StreamEvent(
+                        event_type=StreamEventType.STREAMING,
+                        source=class_name,
+                        data={"token": chunk["token"]},
+                        context=run_context,
+                    )
+                
+                elif chunk["type"] == StreamEventType.THINKING:
+                    yield StreamEvent(
+                        event_type=StreamEventType.THINKING,
+                        source=class_name,
+                        message="Reasoning...",
+                        data={"thinking_content": chunk["content"]},
+                        context=run_context,
+                    )
+                
+                elif chunk["type"] == StreamEventType.TOOL_CALLING:
+                    yield StreamEvent(
+                        event_type=StreamEventType.TOOL_CALLING,
+                        source=class_name,
+                        message=f"Calling tool: {chunk['tool_name']}",
+                        data={"tool_name": chunk["tool_name"], "tool_input": chunk["tool_input"]},
+                        context=run_context,
+                    )
+                
+                elif chunk["type"] == StreamEventType.TOOL_RESULT:
+                    yield StreamEvent(
+                        event_type=StreamEventType.TOOL_RESULT,
+                        source=class_name,
+                        message=f"Tool result: {chunk['tool_name']}",
+                        data={"tool_name": chunk["tool_name"], "tool_output": chunk["tool_output"]},
+                        context=run_context,
+                    )
+                
+                elif chunk["type"] == StreamEventType.COMPLETED:
+                    final_output = chunk["output"]
+
+            if final_output is None:
+                raise ValueError("No output received from LLM")
+
+            if not self.config.stateless:
+                messages.append({"role": "assistant", "content": final_output.model_dump_json(exclude={"type"})})
+                self._memory = messages
+
+            yield StreamEvent(
+                event_type=StreamEventType.COMPLETED,
+                source=class_name,
+                message=f"Completed {class_name}",
+                data={"output": final_output},
+                context=run_context,
+            )
+
+        except Exception as e:
+            yield StreamEvent(
+                event_type=StreamEventType.FAILED,
+                source=class_name,
+                message=f"Failed: {e!s}",
+                data={"error": str(e), "error_type": type(e).__name__},
+                context=run_context,
+            )
+            raise
 
 class FreeFormOutput(OutputSchema):
     """Default output schema for free-form agents."""

--- a/akd_ext/agents/_base.py
+++ b/akd_ext/agents/_base.py
@@ -15,6 +15,8 @@ from openai.types.shared.reasoning import Reasoning
 from pydantic import Field
 
 from akd._base import (
+    Memory,
+    RunContext,
     InputSchema,
     OutputSchema,
     StartingEvent,
@@ -390,7 +392,7 @@ class FreeFormOutput(OutputSchema):
     response: str = Field(..., description="Free-form text response from agent")
 
 
-class FreeFormOpenAIBaseAgent[InSchema: InputSchema](OpenAIBaseAgent[InSchema, FreeFormOutput]):
+class FreeFormOpenAIBaseAgent[InSchema: InputSchema](OpenAIBaseAgent[InSchema, FreeFormOutput, StreamingMixin]):
     """Base for OpenAI agents returning free-form text (no structured output_type).
 
     Use when the agent should return unstructured text that gets wrapped
@@ -405,6 +407,15 @@ class FreeFormOpenAIBaseAgent[InSchema: InputSchema](OpenAIBaseAgent[InSchema, F
     """
 
     output_schema = FreeFormOutput
+
+    def __init__(
+        self,
+        config: OpenAIBaseAgentConfig | None = None,
+        memory: Memory | None = None,
+        **kwargs,
+    ) -> None:
+        super().__init__(config=config, **kwargs)
+        self.memory = memory or Memory()
 
     def _create_agent(self) -> Agent:
         """Create agent WITHOUT output_type (free-form text output)."""
@@ -429,3 +440,52 @@ class FreeFormOpenAIBaseAgent[InSchema: InputSchema](OpenAIBaseAgent[InSchema, F
         # Wrap string response in output schema
         response_text = str(result.final_output)
         return self.output_schema(response=response_text)
+
+    async def _astream(self, params: InSchema, **kwargs) -> AsyncIterator[StreamEvent]:
+        """Stream agent response and yield events."""
+        class_name = self.__class__.__name__
+        run_context = kwargs.get("run_context")
+        if run_context is None:
+            run_context = RunContext()
+
+        yield StartingEvent(
+            source=class_name,
+            message=f"Starting {class_name}",
+            data=StartingEventData[self.input_schema](params=params),
+            run_context=run_context,
+        )
+
+        try:
+            async with self.memory.asession(
+                stateless=self.stateless,
+                run_context=run_context,
+                enable_trimming=self.enable_trimming,
+                model_name=self.model_name,
+                max_tokens=self.max_tokens,
+                trim_ratio=self.trim_ratio,
+            ) as messages:
+                if params:
+                    messages.append({"role": "user", "content": params.model_dump_json(exclude={"type"})})
+
+                yield RunningEvent(
+                    source=class_name,
+                    message=f"Running {class_name}",
+                    data=RunningEventData(),
+                    run_context=run_context,
+                )
+
+                output: FreeFormOutput = await self._arun(params, **kwargs)
+                yield CompletedEvent(
+                    source=class_name,
+                    message=f"Completed {class_name}",
+                    data=CompletedEventData[self.output_schema](output=output),
+                    run_context=run_context,
+                )
+        except Exception as e:
+            yield FailedEvent(
+                source=class_name,
+                message=f"Failed: {e!s}",
+                data=FailedEventData(error=str(e), error_type=type(e).__name__),
+                run_context=run_context,
+            )
+            raise

--- a/akd_ext/agents/_base.py
+++ b/akd_ext/agents/_base.py
@@ -15,7 +15,6 @@ from openai.types.shared.reasoning import Reasoning
 from pydantic import Field
 
 from akd._base import (
-    Memory,
     RunContext,
     InputSchema,
     OutputSchema,
@@ -140,6 +139,17 @@ class OpenAIBaseAgent[InSchema: InputSchema, OutSchema: OutputSchema](BaseAgent,
     def memory(self) -> list[dict[str, Any]]:
         """Conversation history for multi-turn interactions."""
         return self._memory
+
+    @memory.setter
+    def memory(self, value: Any) -> None:
+        """Allow parent class to set memory."""
+        # Parent class passes Memory object, we store as list
+        if hasattr(value, "messages"):
+            self._memory = value.messages
+        elif isinstance(value, list):
+            self._memory = value
+        else:
+            self._memory = []
 
     def reset_memory(self) -> None:
         """Clear conversation history."""
@@ -368,7 +378,13 @@ class OpenAIBaseAgent[InSchema: InputSchema, OutSchema: OutputSchema](BaseAgent,
                 messages.append({"role": "assistant", "content": final_output.model_dump_json(exclude={"type"})})
                 self._memory = messages
 
-            output = response_model.model_validate_json(final_output)
+            # final_output may already be parsed model or JSON string
+            if isinstance(final_output, response_model):
+                output = final_output
+            elif isinstance(final_output, str):
+                output = response_model.model_validate_json(final_output)
+            else:
+                output = response_model.model_validate(final_output)
             yield CompletedEvent(
                 source=class_name,
                 message=f"Completed {class_name}",
@@ -407,15 +423,6 @@ class FreeFormOpenAIBaseAgent[InSchema: InputSchema](OpenAIBaseAgent[InSchema, F
     """
 
     output_schema = FreeFormOutput
-
-    def __init__(
-        self,
-        config: OpenAIBaseAgentConfig | None = None,
-        memory: Memory | None = None,
-        **kwargs,
-    ) -> None:
-        super().__init__(config=config, **kwargs)
-        self.memory = memory or Memory()
 
     def _create_agent(self) -> Agent:
         """Create agent WITHOUT output_type (free-form text output)."""

--- a/akd_ext/agents/_base.py
+++ b/akd_ext/agents/_base.py
@@ -9,11 +9,33 @@ from agents.stream_events import (
     RawResponsesStreamEvent,
     RunItemStreamEvent,
 )
+
 from akd._base.streaming import StreamEvent, StreamEventType, StreamingMixin
 from openai.types.shared.reasoning import Reasoning
 from pydantic import Field
 
-from akd._base import InputSchema, OutputSchema
+from akd._base import (
+    InputSchema,
+    OutputSchema,
+    StartingEvent,
+    StartingEventData,
+    RunningEvent,
+    RunningEventData,
+    StreamingTokenEvent,
+    StreamingEventData,
+    ThinkingEvent,
+    ThinkingEventData,
+    ToolCallingEvent,
+    ToolCallingEventData,
+    ToolCall,
+    ToolResultEvent,
+    ToolResultEventData,
+    ToolResult,
+    CompletedEvent,
+    CompletedEventData,
+    FailedEvent,
+    FailedEventData,
+)
 from akd.agents._base import BaseAgent, BaseAgentConfig
 
 
@@ -81,9 +103,7 @@ class OpenAIBaseAgentConfig(BaseAgentConfig):
         return RunConfig(trace_metadata=self.tracing_params or {})
 
 
-class OpenAIBaseAgent[InSchema: InputSchema, OutSchema: OutputSchema](
-    BaseAgent, StreamingMixin
-):
+class OpenAIBaseAgent[InSchema: InputSchema, OutSchema: OutputSchema](BaseAgent, StreamingMixin):
     """Base class for OpenAI Agents SDK based agents.
 
     Provides:
@@ -192,20 +212,19 @@ class OpenAIBaseAgent[InSchema: InputSchema, OutSchema: OutputSchema](
         token_batch_size: int = 10,
     ) -> AsyncIterator[dict[str, Any]]:
         """Stream using Runner.run_streamed()."""
-        
+
         token_buffer = ""
-        
+
         stream = Runner.run_streamed(
             self._agent,
             input=messages,
             run_config=self.config.run_config,
         )
-        
+
         async for event in stream.stream_events():
-            
             if isinstance(event, RawResponsesStreamEvent):
                 event_type = getattr(event.data, "type", "")
-                
+
                 if event_type == "response.output_text.delta":
                     delta = getattr(event.data, "delta", "") or ""
                     token_buffer += delta
@@ -217,43 +236,41 @@ class OpenAIBaseAgent[InSchema: InputSchema, OutSchema: OutputSchema](
                     if token_buffer:
                         yield {"type": StreamEventType.STREAMING, "token": token_buffer}
                         token_buffer = ""
-                
+
                 elif "reasoning" in event_type:
                     content = getattr(event.data, "content", "") or getattr(event.data, "delta", "") or ""
                     if content:
                         yield {"type": StreamEventType.THINKING, "content": content}
-            
+
             elif isinstance(event, RunItemStreamEvent):
-                
                 if event.name == "tool_called":
                     raw_item = getattr(event.item, "raw_item", None)
                     if raw_item:
                         tool_name = getattr(raw_item, "name", "")
                         tool_input = getattr(raw_item, "arguments", "{}")
                         tool_output = getattr(raw_item, "output", None)
-                        
+
                         yield {
                             "type": StreamEventType.TOOL_CALLING,
                             "tool_name": tool_name,
                             "tool_input": tool_input,
                         }
-                        
+
                         if tool_output:
                             yield {
                                 "type": StreamEventType.TOOL_RESULT,
                                 "tool_name": tool_name,
                                 "tool_output": tool_output,
                             }
-                
+
                 elif event.name == "message_output_created":
                     if token_buffer:
                         yield {"type": StreamEventType.STREAMING, "token": token_buffer}
                         token_buffer = ""
-        
+
         final_output = stream.final_output_as(self.output_schema, raise_if_incorrect_type=False)
         if final_output:
             yield {"type": StreamEventType.COMPLETED, "output": final_output}
-
 
     async def _astream(
         self,
@@ -263,70 +280,82 @@ class OpenAIBaseAgent[InSchema: InputSchema, OutSchema: OutputSchema](
         **kwargs: Any,
     ) -> AsyncIterator[StreamEvent]:
         """Stream execution with akd StreamEvent format."""
-        
+
         class_name = self.__class__.__name__
+        response_model = self.output_schema
         run_context = context.copy() if context else {}
         if "run_id" not in run_context:
             run_context["run_id"] = uuid.uuid4().hex[:8]
 
-        yield StreamEvent(
-            event_type=StreamEventType.STARTING,
+        yield StartingEvent(
             source=class_name,
             message=f"Starting {class_name}",
-            context=run_context,
+            data=StartingEventData[self.input_schema](params=params),
+            run_context=run_context,
         )
 
         try:
             messages = [] if self.config.stateless else self._memory.copy()
-            
+
             if params:
                 messages.append({"role": "user", "content": params.model_dump_json(exclude={"type"})})
 
-            yield StreamEvent(
-                event_type=StreamEventType.RUNNING,
+            yield RunningEvent(
                 source=class_name,
                 message=f"Running {class_name}",
-                context=run_context,
+                data=RunningEventData(),
+                run_context=run_context,
             )
 
             final_output = None
             async for chunk in self._stream_llm_response(messages, token_batch_size=token_batch_size):
-                
                 if chunk["type"] == StreamEventType.STREAMING:
-                    yield StreamEvent(
-                        event_type=StreamEventType.STREAMING,
+                    yield StreamingTokenEvent(
                         source=class_name,
-                        data={"token": chunk["token"]},
-                        context=run_context,
+                        message=f"Streaming {class_name}",
+                        data=StreamingEventData(token=chunk["token"]),
+                        run_context=run_context,
                     )
-                
+
                 elif chunk["type"] == StreamEventType.THINKING:
-                    yield StreamEvent(
-                        event_type=StreamEventType.THINKING,
+                    yield ThinkingEvent(
                         source=class_name,
                         message="Reasoning...",
-                        data={"thinking_content": chunk["content"]},
-                        context=run_context,
+                        data=ThinkingEventData(
+                            thinking_content=chunk["content"]
+                        ),  # check if reflection prompt is used and add reflection_content
+                        run_context=run_context,
                     )
-                
+
                 elif chunk["type"] == StreamEventType.TOOL_CALLING:
-                    yield StreamEvent(
-                        event_type=StreamEventType.TOOL_CALLING,
+                    yield ToolCallingEvent(
                         source=class_name,
                         message=f"Calling tool: {chunk['tool_name']}",
-                        data={"tool_name": chunk["tool_name"], "tool_input": chunk["tool_input"]},
-                        context=run_context,
+                        data=ToolCallingEventData(
+                            tool_call=ToolCall(
+                                tool_call_id=chunk.get("tool_call_id")
+                                or uuid.uuid4().hex[:8],  # does chunk have a tool call id??
+                                tool_name=chunk["tool_name"],
+                                arguments=chunk["tool_input"],
+                            )
+                        ),
+                        run_context=run_context,
                     )
-                
+
                 elif chunk["type"] == StreamEventType.TOOL_RESULT:
-                    yield StreamEvent(
-                        event_type=StreamEventType.TOOL_RESULT,
+                    yield ToolResultEvent(
                         source=class_name,
                         message=f"Tool result: {chunk['tool_name']}",
-                        data={"tool_name": chunk["tool_name"], "tool_output": chunk["tool_output"]},
-                        context=run_context,
+                        result=ToolResultEventData(
+                            tool_result=ToolResult(
+                                tool_call_id=chunk.get("tool_call_id") or uuid.uuid4().hex[:8],
+                                tool_name=chunk["tool_name"],
+                                content=chunk["tool_output"],
+                            )
+                        ),
+                        run_context=run_context,
                     )
-                
+
                 elif chunk["type"] == StreamEventType.COMPLETED:
                     final_output = chunk["output"]
 
@@ -337,23 +366,23 @@ class OpenAIBaseAgent[InSchema: InputSchema, OutSchema: OutputSchema](
                 messages.append({"role": "assistant", "content": final_output.model_dump_json(exclude={"type"})})
                 self._memory = messages
 
-            yield StreamEvent(
-                event_type=StreamEventType.COMPLETED,
+            output = response_model.model_validate_json(final_output)
+            yield CompletedEvent(
                 source=class_name,
                 message=f"Completed {class_name}",
-                data={"output": final_output},
-                context=run_context,
+                data=CompletedEventData[self.output_schema](output=output),
+                run_context=run_context,
             )
 
         except Exception as e:
-            yield StreamEvent(
-                event_type=StreamEventType.FAILED,
+            yield FailedEvent(
                 source=class_name,
                 message=f"Failed: {e!s}",
-                data={"error": str(e), "error_type": type(e).__name__},
-                context=run_context,
+                data=FailedEventData(error=str(e), error_type=type(e).__name__),
+                run_context=run_context,
             )
             raise
+
 
 class FreeFormOutput(OutputSchema):
     """Default output schema for free-form agents."""

--- a/akd_ext/agents/cmr_care.py
+++ b/akd_ext/agents/cmr_care.py
@@ -10,19 +10,29 @@ from __future__ import annotations
 
 import os
 from typing import Any, Literal
+from collections.abc import AsyncIterator
 
 from agents import Agent, HostedMCPTool, ModelSettings
 from loguru import logger
 from openai.types.shared.reasoning import Reasoning
 from pydantic import Field
 
-from akd._base import InputSchema, OutputSchema
+from akd._base import (
+    InputSchema,
+    OutputSchema,
+    CompletedEvent,
+    CompletedEventData,
+    FailedEvent,
+    FailedEventData,
+)
 from akd_ext.agents._base import (
     FreeFormOpenAIBaseAgent,
     FreeFormOutput,
     OpenAIBaseAgent,
     OpenAIBaseAgentConfig,
 )
+
+from akd._base.streaming import StreamEvent
 
 # -----------------------------------------------------------------------------
 # System Prompts
@@ -587,6 +597,53 @@ class CMRCareAgent(OpenAIBaseAgent[CMRCareAgentInputSchema, CMRCareAgentOutputSc
             return self.output_schema(**final_output.model_dump())
         else:
             return self.output_schema.model_validate_json(str(final_output))
+
+    async def _astream(self, params: CMRCareAgentInputSchema, **kwargs) -> AsyncIterator[StreamEvent]:
+        """Orchestrate search -> output pipeline."""
+        if self.config.stateless:
+            self.reset_memory()
+            self._search_agent.reset_memory()
+
+        # Manual iteration to capture return value from async generator
+        search_result_gen = self._search_agent._astream(CMRSearchAgentInputSchema(query=params.query), run_context=None)
+        search_result = None
+
+        async for event in search_result_gen:
+            if isinstance(event, CompletedEvent):
+                search_result = event.data
+            yield event
+
+        if self.debug:
+            logger.debug("Search agent freeform response: {}", search_result.response)
+
+        if not search_result:
+            CompletedEvent(data=CompletedEventData[self.output_schema](output=self.output_schema()))
+
+        # self._memory.extend(search_result.to_input_list())
+        self._memory = self._search_agent.memory
+        conversation_message = self._memory
+
+        try:
+            result = await self.get_response_async(messages=conversation_message)
+        except Exception as e:
+            logger.error("Error in output agent: {}", e)
+            yield FailedEvent(data=FailedEventData(error=str(e), error_type=type(e).__name__))
+
+        # Return typed output
+        final_output = result.final_output
+
+        if isinstance(final_output, self.output_schema):
+            yield CompletedEvent(data=CompletedEventData[self.output_schema](output=final_output))
+        elif hasattr(final_output, "model_dump"):
+            yield CompletedEvent(
+                data=CompletedEventData[self.output_schema](output=self.output_schema(**final_output.model_dump()))
+            )
+        else:
+            yield CompletedEvent(
+                data=CompletedEventData[self.output_schema](
+                    output=self.output_schema.model_validate_json(str(final_output))
+                )
+            )
 
 
 if __name__ == "__main__":

--- a/akd_ext/agents/cmr_care.py
+++ b/akd_ext/agents/cmr_care.py
@@ -20,10 +20,15 @@ from pydantic import Field
 from akd._base import (
     InputSchema,
     OutputSchema,
+    StartingEvent,
+    StartingEventData,
+    RunningEvent,
+    RunningEventData,
     CompletedEvent,
     CompletedEventData,
     FailedEvent,
     FailedEventData,
+    HumanInputRequiredEvent,
 )
 from akd_ext.agents._base import (
     FreeFormOpenAIBaseAgent,
@@ -33,6 +38,10 @@ from akd_ext.agents._base import (
 )
 
 from akd._base.streaming import StreamEvent
+
+from agents import function_tool
+from akd_ext.mcp.converter import tool_converter
+from akd.tools.human import HumanTool
 
 # -----------------------------------------------------------------------------
 # System Prompts
@@ -443,7 +452,8 @@ def _default_cmr_tools() -> list[Any]:
                     "https://w4hu71445m.execute-api.us-east-1.amazonaws.com/mcp/cmr/mcp",
                 ),
             }
-        )
+        ),
+        function_tool(tool_converter(HumanTool())),
     ]
 
 
@@ -598,8 +608,18 @@ class CMRCareAgent(OpenAIBaseAgent[CMRCareAgentInputSchema, CMRCareAgentOutputSc
         else:
             return self.output_schema.model_validate_json(str(final_output))
 
-    async def _astream(self, params: CMRCareAgentInputSchema, **kwargs) -> AsyncIterator[StreamEvent]:
+    async def _astream(
+        self,
+        params: CMRCareAgentInputSchema,
+        context: dict[str, Any] | None = None,
+        token_batch_size: int = 10,
+        **kwargs: Any,
+    ) -> AsyncIterator[StreamEvent]:
         """Orchestrate search -> output pipeline."""
+
+        class_name = self.__class__.__name__
+        run_context = context.copy() if context else {}
+
         if self.config.stateless:
             self.reset_memory()
             self._search_agent.reset_memory()
@@ -607,23 +627,44 @@ class CMRCareAgent(OpenAIBaseAgent[CMRCareAgentInputSchema, CMRCareAgentOutputSc
         # Manual iteration to capture return value from async generator
         search_result_gen = self._search_agent._astream(CMRSearchAgentInputSchema(query=params.query), run_context=None)
         search_result = None
+        run_context = {}
 
         async for event in search_result_gen:
             if isinstance(event, CompletedEvent):
-                search_result = event.data
+                search_result = event.data.output.response
+                run_context = event.run_context
+            if isinstance(event, HumanInputRequiredEvent):
+                yield event
+                # halt for user event
+                return
             yield event
 
         if self.debug:
-            logger.debug("Search agent freeform response: {}", search_result.response)
+            logger.debug("Search agent freeform response: {}", search_result)
 
         if not search_result:
-            CompletedEvent(data=CompletedEventData[self.output_schema](output=self.output_schema()))
+            yield FailedEvent(
+                data=FailedEventData(error="No search result to further process", error_type="ValueError")
+            )
+            return
 
-        # self._memory.extend(search_result.to_input_list())
         self._memory = self._search_agent.memory
         conversation_message = self._memory
 
+        yield StartingEvent(
+            source=class_name,
+            message=f"Starting {class_name}",
+            data=StartingEventData[self.input_schema](query=search_result),
+            run_context=run_context,
+        )
+
         try:
+            yield RunningEvent(
+                source=class_name,
+                message=f"Running {class_name}",
+                data=RunningEventData(),
+                run_context=run_context,
+            )
             result = await self.get_response_async(messages=conversation_message)
         except Exception as e:
             logger.error("Error in output agent: {}", e)
@@ -636,13 +677,15 @@ class CMRCareAgent(OpenAIBaseAgent[CMRCareAgentInputSchema, CMRCareAgentOutputSc
             yield CompletedEvent(data=CompletedEventData[self.output_schema](output=final_output))
         elif hasattr(final_output, "model_dump"):
             yield CompletedEvent(
-                data=CompletedEventData[self.output_schema](output=self.output_schema(**final_output.model_dump()))
+                data=CompletedEventData[self.output_schema](output=self.output_schema(**final_output.model_dump())),
+                class_name=class_name,
             )
         else:
             yield CompletedEvent(
                 data=CompletedEventData[self.output_schema](
                     output=self.output_schema.model_validate_json(str(final_output))
-                )
+                ),
+                class_name=class_name,
             )
 
 

--- a/akd_ext/agents/cmr_care.py
+++ b/akd_ext/agents/cmr_care.py
@@ -655,7 +655,7 @@ if __name__ == "__main__":
 
         question = "Can you find me datasets about sea ice?"
 
-        async for event in agent.astream(
+        async for event in agent._astream(
             CMRCareAgentInputSchema(query=question),
         ):
             print(event)

--- a/akd_ext/agents/cmr_care.py
+++ b/akd_ext/agents/cmr_care.py
@@ -560,9 +560,9 @@ class CMRCareAgent(OpenAIBaseAgent[CMRCareAgentInputSchema, CMRCareAgentOutputSc
         1. Run search agent with user query
         2. Pass FULL conversation history (including tool calls) to output agent
         """
-        if self.config.stateless:
-            self.reset_memory()
-            self._search_agent.reset_memory()
+        # if self.config.stateless:
+        #     self.reset_memory()
+        #     self._search_agent.reset_memory()
 
         # Stage 1: Run search agent (free-form)
         search_input = CMRSearchAgentInputSchema(query=params.query)
@@ -577,7 +577,7 @@ class CMRCareAgent(OpenAIBaseAgent[CMRCareAgentInputSchema, CMRCareAgentOutputSc
         result = await self.get_response_async(messages=search_conversation)
 
         # Update our memory with the full conversation
-        self._memory = result.to_input_list()
+        # self._memory = result.to_input_list()
 
         # Return typed output
         final_output = result.final_output
@@ -587,3 +587,20 @@ class CMRCareAgent(OpenAIBaseAgent[CMRCareAgentInputSchema, CMRCareAgentOutputSc
             return self.output_schema(**final_output.model_dump())
         else:
             return self.output_schema.model_validate_json(str(final_output))
+
+
+if __name__ == "__main__":
+    import asyncio
+
+    async def main():
+        config = CMRCareConfig()
+        agent = CMRCareAgent(config=config)
+
+        question = "Can you find me datasets about sea ice?"
+
+        async for event in agent.astream(
+            CMRCareAgentInputSchema(query=question),
+        ):
+            print(event)
+
+    asyncio.run(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
 ]
 requires-python = ">=3.12"
 dependencies = [
-    "akd @ git+https://github.com/NASA-IMPACT/accelerated-discovery.git@develop",
+    "akd @ git+https://github.com/NASA-IMPACT/accelerated-discovery.git@feature/human-chat",
     "fastmcp>=2.0.0",
     "openai-agents>=0.6.7",
     "PyGithub>=2.1.1",

--- a/uv.lock
+++ b/uv.lock
@@ -144,7 +144,7 @@ wheels = [
 [[package]]
 name = "akd"
 version = "0.1.0"
-source = { git = "https://github.com/NASA-IMPACT/accelerated-discovery.git?rev=develop#9477008cfe4029158a1b430e5ad6150bece8717a" }
+source = { git = "https://github.com/NASA-IMPACT/accelerated-discovery.git?rev=feature%2Fhuman-chat#9370f8659460856a347c7b99227a010ed25df3e5" }
 dependencies = [
     { name = "crawl4ai" },
     { name = "dateparser" },
@@ -209,7 +209,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "akd", git = "https://github.com/NASA-IMPACT/accelerated-discovery.git?rev=develop" },
+    { name = "akd", git = "https://github.com/NASA-IMPACT/accelerated-discovery.git?rev=feature%2Fhuman-chat" },
     { name = "fastmcp", specifier = ">=2.0.0" },
     { name = "openai-agents", specifier = ">=0.6.7" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.2.0" },


### PR DESCRIPTION
## Summary
Add streaming support to `OpenAIBaseAgent` in akd-ext, enabling real-time token streaming and tool call events following the akd-core streaming spec.

## What it does

Enables `agent.astream()` method for OpenAI Agents SDK based agents with support for STARTING, RUNNING, STREAMING, THINKING, TOOL_CALLING , TOOL_RESULT, COMPLETED, FAILED

## How it does

1. **Added `StreamingMixin`** to `OpenAIBaseAgent` class
   - Provides `astream()` public method with input/output validation

2. **Implemented `_stream_llm_response()`** method
   - Uses `Runner.run_streamed()` instead of `Runner.run()`
   - Handles `RawResponsesStreamEvent` for text tokens and thinking
   - Handles `RunItemStreamEvent` for tool calls (via `event.item.raw_item`)
   - Token batching for efficiency (default `batch_size=10`)

3. **Implemented `_astream()`** method
   - Converts internal stream format to akd `StreamEvent` objects
   
   
## Tested streaming with MCP Tools
```python
from agents import HostedMCPTool
from pydantic import Field
from akd._base import InputSchema, OutputSchema
from akd._base.streaming import StreamEventType
from akd_ext.agents._base import OpenAIBaseAgent, OpenAIBaseAgentConfig


class QIn(InputSchema):
    """Input."""
    q: str = Field(..., description="Question")


class QOut(OutputSchema):
    """Output."""
    a: str = Field(..., description="Answer")


# Auto-approve MCP tool calls
async def auto_approve(request) -> dict:
    """Automatically approve all MCP tool calls."""
    print(f"Auto-approving: {request}")
    return {"approve": True}


# MCP Tool setup
mcp_tool = HostedMCPTool(
    tool_config={
        "type": "mcp",
        "server_url": "YOUR_MCP_SERVER_URL",
        "server_label": "your_label",
        "headers": {
            "Authorization": "Bearer YOUR_TOKEN",
        }
    },
    on_approval_request=auto_approve,
)


class MCPTestAgent(OpenAIBaseAgent[QIn, QOut]):
    input_schema = QIn
    output_schema = QOut


config = OpenAIBaseAgentConfig(
    model_name="gpt-4o-mini",
    system_prompt="You are a helpful assistant. Use tools when needed.",
    tools=[mcp_tool],
)

agent = MCPTestAgent(config=config)

print(f"Agent created with MCP tools!")
print(f"Tools: {config.tools}")

# Test with tool calling
question = "Use the dummy tool with input 'hello world'"

async for event in agent.astream(QIn(q=question)):
    
    print(f"[{event.event_type.upper()}]", end=" ")
    if event.event_type == StreamEventType.TOOL_CALLING:
        print(f"TOOL: {event.data.get('tool_name')}")
        print(f"INPUT: {event.data.get('tool_input')}")
    elif event.event_type == StreamEventType.TOOL_RESULT:
        print(f"RESULT: {event.data.get('tool_output')}")
    elif event.event_type == StreamEventType.STREAMING:
        print(f"Token: '{event.token}'")
    elif event.event_type == StreamEventType.COMPLETED:
        print(f"Final: {event.output}")
    else:
        print()
```

