### PR TITLE
fix: add space after # in CMR CARE agent markdown headings

### DIFF
--- a/akd_ext/agents/cmr_care.py
+++ b/akd_ext/agents/cmr_care.py
@@ -109,6 +109,7 @@ CMR_DATA_SEARCH_CARE_AGENT_SYSTEM_PROMPT = """ROLE
 
     OUTPUT FORMAT
     All responses must follow this structure exactly. No free-form text is allowed outside these sections.
+    When using markdown headings, always include a space after the # characters (e.g., "## 1. Section Title" not "##1. Section Title").
     1. Clarifying Questions
     Included only when required inputs are missing
     Blocking; no continuation until answered

--- a/tests/agents/test_cmr_care.py
+++ b/tests/agents/test_cmr_care.py
@@ -1,7 +1,4 @@
-"""Functional tests for CMR CARE Agent.
-
-Co-Authored-By: Sanjog Thapa <sanzog03@gmail.com>
-"""
+"""Functional tests for CMR CARE Agent."""
 
 import pytest
 
@@ -37,3 +34,18 @@ async def test_cmr_care_agent(query: str, reasoning_effort: str):
     assert isinstance(result, (CMRCareAgentOutputSchema, TextOutput))
     if isinstance(result, CMRCareAgentOutputSchema):
         assert len(result.dataset_concept_ids) > 0
+
+
+# To test the markdown heading format, uncomment the following test function and run the test
+# @pytest.mark.asyncio
+# async def test_cmr_care_agent_markdown_heading_format(reasoning_effort: str):
+#     """Test that CMR CARE Agent produces valid markdown headings with spaces after # characters."""
+#     config = CMRCareConfig(reasoning_effort=reasoning_effort)
+#     agent = CMRCareAgent(config=config)
+#     result = await agent.arun(
+#         CMRCareAgentInputSchema(query="Find datasets related to sea surface temperature in the Pacific Ocean")
+#     )
+#     assert isinstance(result, (CMRCareAgentOutputSchema, TextOutput))
+#     if isinstance(result, CMRCareAgentOutputSchema):
+#         broken_headings = re.findall(r"^#{1,6}[^ #\n]", result.report, re.MULTILINE)
+#         assert broken_headings == [], f"Malformed headings (missing space after #): {broken_headings}"


### PR DESCRIPTION
**Issue:** 
Bug Ticket: [Agent chat streams malformed markdown heading syntax](https://github.com/NASA-IMPACT/akd-framework/issues/128)

**What changes I have made:**

- Added explicit markdown formatting instruction to the CMR CARE agent system prompt in akd_ext/agents/cmr_care.py. The instruction tells the LLM to always include a space after # characters in headings

**How to test:**

- Set OPENAI_API_KEY in .env
- Uncomment test_cmr_care_agent_markdown_heading_format in tests/agents/test_cmr_care.py
- Run below command: 
```
uv run pytest "tests/agents/test_cmr_care.py::test_cmr_care_agent[Find datasets related to sea surface temperature in the Pacific Ocean]" -s -o "addopts="
```
(above test simply ignores the default pytest flags from config and simply runs this single test)

- Optionally uncomment test_cmr_care_agent_markdown_heading_format in test_cmr_care.py to run the automated regex check


