### PR TITLE
Add file attachment support for agents

### DIFF
--- a/akd_ext/agents/__init__.py
+++ b/akd_ext/agents/__init__.py
@@ -1,6 +1,7 @@
 """Agents module for akd_ext."""
 
 from akd_ext.agents._base import OpenAIBaseAgent, OpenAIBaseAgentConfig
+from akd_ext.agents._mixins import FileAttachmentMixin
 from akd_ext.agents.cmr_care import (
     CMRCareAgent,
     CMRCareAgentInputSchema,
@@ -11,6 +12,7 @@ from akd_ext.agents.cmr_care import (
 __all__ = [
     "OpenAIBaseAgent",
     "OpenAIBaseAgentConfig",
+    "FileAttachmentMixin",
     "CMRCareAgent",
     "CMRCareAgentInputSchema",
     "CMRCareAgentOutputSchema",

--- a/akd_ext/agents/_base.py
+++ b/akd_ext/agents/_base.py
@@ -59,6 +59,8 @@ from akd._base.errors import (
 
 from akd.utils import PartialModel
 
+from akd_ext.agents._mixins import FileAttachmentMixin
+
 from akd_ext._types import AKDTool, OPENAI_TOOL_TYPES
 from akd_ext.mcp.converter import tool_converter
 
@@ -150,7 +152,9 @@ class OpenAIBaseAgentConfig(BaseAgentConfig):
         return RunConfig(trace_metadata=self.tracing_params or {})
 
 
-class OpenAIBaseAgent[InSchema: InputSchema, OutSchema: OutputSchema](OutputRoutingMixin, BaseAgent, StreamingMixin):
+class OpenAIBaseAgent[InSchema: InputSchema, OutSchema: OutputSchema](
+    FileAttachmentMixin, OutputRoutingMixin, BaseAgent, StreamingMixin
+):
     """Base class for OpenAI Agents SDK based agents.
 
     Follows the akd-core BaseAgent template pattern:
@@ -454,6 +458,9 @@ class OpenAIBaseAgent[InSchema: InputSchema, OutSchema: OutputSchema](OutputRout
         - Direct mode (no tools, no union multi_tool): Runner.run() via get_response_async
         - Tool/union mode: consumes _run_engine_stream() watching for CompletedEvent
         """
+        # Resolve and inject file attachments before LLM call
+        await self._resolve_and_inject_files(run_context.messages, run_context)
+
         has_union = len(self.output_schema_resolved) > 1
         use_tool_loop = bool(self.config.tools) or (has_union and self.output_mode == "multi_tool")
 

--- a/akd_ext/agents/_mixins.py
+++ b/akd_ext/agents/_mixins.py
@@ -1,0 +1,49 @@
+"""Mixins for agent capabilities."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from akd._base import RunContext
+
+from akd_ext.files import DEFAULT_RESOLVERS, FileAttachment, FileResolver
+
+
+class FileAttachmentMixin:
+    """Mixin that gives any agent file attachment capability.
+
+    Lightweight orchestration only — all resolution logic lives in FileResolver implementations.
+    Add to an agent's inheritance to enable file context injection before LLM calls.
+
+    Usage:
+        class MyAgent(FileAttachmentMixin, BaseAgent[In, Out]):
+            ...
+
+    The mixin reads ``file_attachments`` from RunContext (passed as an extra field)
+    and resolves them into multipart content parts injected into the last user message.
+    """
+
+    file_resolvers: dict[type[FileAttachment], FileResolver] = DEFAULT_RESOLVERS
+
+    async def _resolve_and_inject_files(
+        self,
+        messages: list[dict[str, Any]],
+        run_context: RunContext,
+    ) -> None:
+        """Resolve file attachments and inject content into the last user message."""
+        attachments: list[FileAttachment] = getattr(run_context, "file_attachments", [])
+        if not attachments:
+            return
+
+        # Find last user message and convert to multipart content array
+        for msg in reversed(messages):
+            if msg.get("role") == "user":
+                existing = msg["content"]
+                parts = [{"type": "text", "text": existing}] if isinstance(existing, str) else list(existing)
+                for att in attachments:
+                    resolver = self.file_resolvers.get(type(att))
+                    if resolver is None:
+                        raise TypeError(f"No resolver registered for attachment type {type(att).__name__}")
+                    parts.extend(await resolver.resolve(att))
+                msg["content"] = parts
+                break

--- a/akd_ext/files.py
+++ b/akd_ext/files.py
@@ -1,0 +1,92 @@
+"""File attachment data models and resolvers for agent file context injection."""
+
+from __future__ import annotations
+
+import base64
+from typing import Any, Protocol, runtime_checkable
+
+import httpx
+from pydantic import BaseModel, Field
+
+
+# ── Data Models ──────────────────────────────────────────────────────
+
+
+class FileAttachment(BaseModel):
+    """Base file attachment — shared metadata."""
+
+    file_id: str = Field(..., description="Unique identifier from backend")
+    filename: str = Field(..., description="Original filename")
+    mime_type: str = Field(default="application/octet-stream", description="MIME type of the file")
+
+
+class OpenAIFileAttachment(FileAttachment):
+    """File uploaded via OpenAI Files API."""
+
+    openai_file_id: str = Field(..., description="OpenAI Files API file ID")
+
+
+class URLFileAttachment(FileAttachment):
+    """File accessible via URL (presigned S3, GCS signed, etc.)."""
+
+    url: str = Field(..., description="URL to fetch content from")
+
+
+# ── Resolver Protocol + Implementations ──────────────────────────────
+
+
+@runtime_checkable
+class FileResolver(Protocol):
+    """Turns a FileAttachment into Chat Completions multipart content parts."""
+
+    async def resolve(self, attachment: FileAttachment) -> list[dict[str, Any]]: ...
+
+
+class OpenAIFileResolver:
+    """Passes file_id natively to OpenAI — no fetching needed."""
+
+    async def resolve(self, attachment: OpenAIFileAttachment) -> list[dict[str, Any]]:
+        return [{"type": "file", "file": {"file_id": attachment.openai_file_id}}]
+
+
+class URLFileResolver:
+    """Fetches content from URL and inlines it into the message."""
+
+    def __init__(self, client: httpx.AsyncClient | None = None, timeout: float = 30.0):
+        self._client = client
+        self._timeout = timeout
+
+    async def _get_client(self) -> httpx.AsyncClient:
+        if self._client is None:
+            self._client = httpx.AsyncClient(timeout=self._timeout)
+        return self._client
+
+    async def _fetch(self, url: str) -> bytes:
+        client = await self._get_client()
+        response = await client.get(url)
+        response.raise_for_status()
+        return response.content
+
+    async def resolve(self, attachment: URLFileAttachment) -> list[dict[str, Any]]:
+        raw = await self._fetch(attachment.url)
+
+        if attachment.mime_type.startswith("image/"):
+            encoded = base64.b64encode(raw).decode("utf-8")
+            return [
+                {
+                    "type": "image_url",
+                    "image_url": {"url": f"data:{attachment.mime_type};base64,{encoded}"},
+                }
+            ]
+
+        # Text-based files
+        text = raw.decode("utf-8")
+        return [{"type": "text", "text": f"[File: {attachment.filename}]\n{text}"}]
+
+
+# ── Default Resolver Registry ────────────────────────────────────────
+
+DEFAULT_RESOLVERS: dict[type[FileAttachment], FileResolver] = {
+    OpenAIFileAttachment: OpenAIFileResolver(),
+    URLFileAttachment: URLFileResolver(),
+}

--- a/tests/test_file_attachment_mixin.py
+++ b/tests/test_file_attachment_mixin.py
@@ -1,0 +1,147 @@
+"""Unit tests for FileAttachmentMixin."""
+
+import pytest
+
+from akd._base import RunContext
+
+from akd_ext.agents._mixins import FileAttachmentMixin
+from akd_ext.files import (
+    FileAttachment,
+    OpenAIFileAttachment,
+    OpenAIFileResolver,
+    URLFileAttachment,
+)
+
+
+class DummyResolver:
+    """Test resolver that returns a fixed content part."""
+
+    def __init__(self, parts: list[dict]):
+        self.parts = parts
+
+    async def resolve(self, attachment: FileAttachment) -> list[dict]:
+        return self.parts
+
+
+class MixinHost(FileAttachmentMixin):
+    """Minimal host class to test the mixin."""
+
+    pass
+
+
+@pytest.fixture
+def mixin():
+    host = MixinHost()
+    host.file_resolvers = {
+        OpenAIFileAttachment: OpenAIFileResolver(),
+        URLFileAttachment: DummyResolver([{"type": "text", "text": "[File: test.csv]\ncol1,col2"}]),
+    }
+    return host
+
+
+class TestFileAttachmentMixin:
+    @pytest.mark.asyncio
+    async def test_no_attachments_is_noop(self, mixin):
+        """Messages unchanged when no file_attachments on RunContext."""
+        messages = [{"role": "user", "content": "hello"}]
+        run_context = RunContext(messages=messages)
+
+        await mixin._resolve_and_inject_files(messages, run_context)
+
+        assert messages[0]["content"] == "hello"
+
+    @pytest.mark.asyncio
+    async def test_inject_openai_file(self, mixin):
+        """OpenAI file attachment is injected into last user message."""
+        messages = [{"role": "user", "content": "Analyze this file"}]
+        att = OpenAIFileAttachment(file_id="f1", filename="report.pdf", openai_file_id="file-abc")
+        run_context = RunContext(messages=messages, file_attachments=[att])
+
+        await mixin._resolve_and_inject_files(messages, run_context)
+
+        content = messages[0]["content"]
+        assert isinstance(content, list)
+        assert content[0] == {"type": "text", "text": "Analyze this file"}
+        assert content[1] == {"type": "file", "file": {"file_id": "file-abc"}}
+
+    @pytest.mark.asyncio
+    async def test_inject_url_file(self, mixin):
+        """URL file attachment is injected into last user message."""
+        messages = [{"role": "user", "content": "Check this data"}]
+        att = URLFileAttachment(
+            file_id="f2", filename="test.csv", mime_type="text/csv", url="https://example.com/test.csv"
+        )
+        run_context = RunContext(messages=messages, file_attachments=[att])
+
+        await mixin._resolve_and_inject_files(messages, run_context)
+
+        content = messages[0]["content"]
+        assert isinstance(content, list)
+        assert content[0] == {"type": "text", "text": "Check this data"}
+        assert content[1]["type"] == "text"
+        assert "[File: test.csv]" in content[1]["text"]
+
+    @pytest.mark.asyncio
+    async def test_inject_multiple_attachments(self, mixin):
+        """Multiple attachments are all injected."""
+        messages = [{"role": "user", "content": "Compare these"}]
+        att1 = OpenAIFileAttachment(file_id="f1", filename="a.pdf", openai_file_id="file-a")
+        att2 = OpenAIFileAttachment(file_id="f2", filename="b.pdf", openai_file_id="file-b")
+        run_context = RunContext(messages=messages, file_attachments=[att1, att2])
+
+        await mixin._resolve_and_inject_files(messages, run_context)
+
+        content = messages[0]["content"]
+        assert len(content) == 3  # original text + 2 file parts
+
+    @pytest.mark.asyncio
+    async def test_inject_targets_last_user_message(self, mixin):
+        """Files are injected into the last user message, not earlier ones."""
+        messages = [
+            {"role": "user", "content": "first message"},
+            {"role": "assistant", "content": "response"},
+            {"role": "user", "content": "second message"},
+        ]
+        att = OpenAIFileAttachment(file_id="f1", filename="report.pdf", openai_file_id="file-abc")
+        run_context = RunContext(messages=messages, file_attachments=[att])
+
+        await mixin._resolve_and_inject_files(messages, run_context)
+
+        # First user message unchanged
+        assert messages[0]["content"] == "first message"
+        # Last user message converted to multipart
+        assert isinstance(messages[2]["content"], list)
+
+    @pytest.mark.asyncio
+    async def test_existing_multipart_content_preserved(self, mixin):
+        """If content is already multipart, existing parts are preserved."""
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "existing text"},
+                    {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+                ],
+            }
+        ]
+        att = OpenAIFileAttachment(file_id="f1", filename="report.pdf", openai_file_id="file-abc")
+        run_context = RunContext(messages=messages, file_attachments=[att])
+
+        await mixin._resolve_and_inject_files(messages, run_context)
+
+        content = messages[0]["content"]
+        assert len(content) == 3  # 2 existing + 1 new
+
+    @pytest.mark.asyncio
+    async def test_unregistered_attachment_type_raises(self, mixin):
+        """TypeError raised for attachment types without a registered resolver."""
+
+        class CustomAttachment(FileAttachment):
+            custom_field: str = "x"
+
+        messages = [{"role": "user", "content": "test"}]
+        att = CustomAttachment(file_id="f1", filename="test.txt", custom_field="x")
+        run_context = RunContext(messages=messages, file_attachments=[att])
+
+        with pytest.raises(TypeError, match="No resolver registered"):
+            await mixin._resolve_and_inject_files(messages, run_context)

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -1,0 +1,136 @@
+"""Unit tests for file attachment data models and resolvers."""
+
+import base64
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from akd_ext.files import (
+    FileAttachment,
+    OpenAIFileAttachment,
+    OpenAIFileResolver,
+    URLFileAttachment,
+    URLFileResolver,
+)
+
+
+# ── Data Model Tests ─────────────────────────────────────────────────
+
+
+class TestFileAttachmentModels:
+    def test_base_attachment(self):
+        att = FileAttachment(file_id="f1", filename="test.txt")
+        assert att.file_id == "f1"
+        assert att.filename == "test.txt"
+        assert att.mime_type == "application/octet-stream"
+
+    def test_openai_attachment(self):
+        att = OpenAIFileAttachment(file_id="f1", filename="report.pdf", openai_file_id="file-abc123")
+        assert att.openai_file_id == "file-abc123"
+        assert isinstance(att, FileAttachment)
+
+    def test_openai_attachment_requires_openai_file_id(self):
+        with pytest.raises(Exception):
+            OpenAIFileAttachment(file_id="f1", filename="test.txt")
+
+    def test_url_attachment(self):
+        att = URLFileAttachment(file_id="f1", filename="data.csv", url="https://example.com/data.csv")
+        assert att.url == "https://example.com/data.csv"
+        assert isinstance(att, FileAttachment)
+
+    def test_url_attachment_requires_url(self):
+        with pytest.raises(Exception):
+            URLFileAttachment(file_id="f1", filename="test.txt")
+
+    def test_mime_type_override(self):
+        att = URLFileAttachment(
+            file_id="f1", filename="img.png", mime_type="image/png", url="https://example.com/img.png"
+        )
+        assert att.mime_type == "image/png"
+
+
+# ── OpenAIFileResolver Tests ────────────────────────────────────────
+
+
+class TestOpenAIFileResolver:
+    @pytest.mark.asyncio
+    async def test_resolve_returns_file_content_part(self):
+        resolver = OpenAIFileResolver()
+        att = OpenAIFileAttachment(file_id="f1", filename="report.pdf", openai_file_id="file-abc123")
+        parts = await resolver.resolve(att)
+
+        assert len(parts) == 1
+        assert parts[0] == {"type": "file", "file": {"file_id": "file-abc123"}}
+
+
+# ── URLFileResolver Tests ───────────────────────────────────────────
+
+
+class TestURLFileResolver:
+    @pytest.mark.asyncio
+    async def test_resolve_text_file(self):
+        """Text file content is inlined with filename header."""
+        resolver = URLFileResolver()
+        resolver._fetch = AsyncMock(return_value=b"col1,col2\na,b")
+
+        att = URLFileAttachment(
+            file_id="f1", filename="data.csv", mime_type="text/csv", url="https://example.com/data.csv"
+        )
+        parts = await resolver.resolve(att)
+
+        assert len(parts) == 1
+        assert parts[0]["type"] == "text"
+        assert "[File: data.csv]" in parts[0]["text"]
+        assert "col1,col2" in parts[0]["text"]
+        resolver._fetch.assert_awaited_once_with("https://example.com/data.csv")
+
+    @pytest.mark.asyncio
+    async def test_resolve_image_file(self):
+        """Image file is base64-encoded as image_url content part."""
+        image_bytes = b"\x89PNG\r\n\x1a\n"  # PNG header
+        resolver = URLFileResolver()
+        resolver._fetch = AsyncMock(return_value=image_bytes)
+
+        att = URLFileAttachment(
+            file_id="f1", filename="img.png", mime_type="image/png", url="https://example.com/img.png"
+        )
+        parts = await resolver.resolve(att)
+
+        assert len(parts) == 1
+        assert parts[0]["type"] == "image_url"
+        expected_b64 = base64.b64encode(image_bytes).decode("utf-8")
+        assert parts[0]["image_url"]["url"] == f"data:image/png;base64,{expected_b64}"
+
+    @pytest.mark.asyncio
+    async def test_resolve_with_custom_client(self):
+        """Resolver accepts a custom client."""
+        resolver = URLFileResolver(timeout=60.0)
+        resolver._fetch = AsyncMock(return_value=b"hello")
+
+        att = URLFileAttachment(
+            file_id="f1", filename="file.txt", mime_type="text/plain", url="https://example.com/file.txt"
+        )
+        parts = await resolver.resolve(att)
+
+        assert parts[0]["type"] == "text"
+        assert "hello" in parts[0]["text"]
+
+    @pytest.mark.asyncio
+    async def test_resolve_http_error_raises(self):
+        """HTTP errors propagate."""
+        resolver = URLFileResolver()
+        resolver._fetch = AsyncMock(
+            side_effect=httpx.HTTPStatusError(
+                "Not Found",
+                request=httpx.Request("GET", "https://example.com/missing.txt"),
+                response=httpx.Response(404),
+            )
+        )
+
+        att = URLFileAttachment(
+            file_id="f1", filename="missing.txt", mime_type="text/plain", url="https://example.com/missing.txt"
+        )
+
+        with pytest.raises(httpx.HTTPStatusError):
+            await resolver.resolve(att)


### PR DESCRIPTION
## Summary

  Adds the ability for agents to receive and process file context through a new file attachment system. Files uploaded by the backend (via OpenAI Files API or cloud storage like S3) can now be resolved and injected into agent messages before LLM calls.

  ## What it does

  - Introduces a `FileAttachment` data model hierarchy for representing file references (OpenAI file IDs or URLs)
  - Provides a `FileResolver` protocol with two implementations: `OpenAIFileResolver` (native file_id passthrough) and `URLFileResolver` (fetches content from presigned URLs and inlines it). Todo: make url file resolver better in next iteration. 
  - Adds a `FileAttachmentMixin` that wires file resolution into the agent execution path
  - All `OpenAIBaseAgent` subclasses now automatically support file attachments passed via `RunContext`

  ## How it does this

  Three-layer design:

  1. **Data models** (`akd_ext/files.py`): `FileAttachment` base with `OpenAIFileAttachment` and `URLFileAttachment` subclasses — pure data, no behavior
  2. **Resolvers** (`akd_ext/files.py`): `FileResolver` protocol with `OpenAIFileResolver` (returns native `file_id` reference) and `URLFileResolver` (fetches URL content, inlines as text or base64 image).
  Resolvers are standalone, testable, and configurable (e.g. custom HTTP client/timeout)
  3. **Mixin** (`akd_ext/agents/_mixins.py`): `FileAttachmentMixin` provides lightweight orchestration — reads `file_attachments` from `RunContext` (extra field, no core changes needed), dispatches to the correct resolver by attachment type, and injects resolved content parts into the last user message as a multipart content array

 The mixin is added to `OpenAIBaseAgent`'s inheritance chain and `_resolve_and_inject_files()` is called in `_arun()` before the LLM call. The existing `_to_runner_input()` already passes `msg["content"]` through as-is, so multipart content arrays flow to the OpenAI API without additional changes. 
 
 Note: The file context feature can be limited to selected agents only, i.e. by applying mixins to those specific agents.

Backend usage:
  ```python
  from akd_ext.files import OpenAIFileAttachment, URLFileAttachment

  # OpenAI Files API
  attachment = OpenAIFileAttachment(
      file_id="upload-123", filename="report.pdf",
      mime_type="application/pdf",
      openai_file_id="file-abc123",
  )

  # Cloud storage (S3, GCS, etc.)
  attachment = URLFileAttachment(
      file_id="upload-456", filename="data.csv",
      mime_type="text/csv",
      url="https://bucket.s3.amazonaws.com/data.csv?X-Amz-...",
  )

  run_context = RunContext(file_attachments=[attachment])
  result = await agent.arun(input_schema, run_context=run_context)

  Testing

  # Run all new tests
  uv run pytest tests/test_files.py tests/test_file_attachment_mixin.py -v

  # Run resolver tests only
  uv run pytest tests/test_files.py -v

  # Run mixin tests only
  uv run pytest tests/test_file_attachment_mixin.py -v
