### PR TITLE
fix: correct OpenAI file attachment and enable file injection in astream

### DIFF
--- a/akd_ext/agents/_base.py
+++ b/akd_ext/agents/_base.py
@@ -476,6 +476,18 @@ class OpenAIBaseAgent[InSchema: InputSchema, OutSchema: OutputSchema](
 
         raise UnexpectedModelBehavior("Tool loop completed without producing output")
 
+    # overriding astream to include file upload mixin functionality
+    async def astream(
+        self,
+        params: Any,
+        run_context: RunContext | None = None,
+        **kwargs: Any,
+    ) -> AsyncIterator[StreamEvent]:
+        # Resolve and inject file attachments before LLM call
+        await self._resolve_and_inject_files(run_context.messages, run_context)
+        async for event in super().astream(params=params, run_context=run_context, **kwargs):
+            yield event
+
     # ── Output resolution ────────────────────────────────────────────
 
     def _resolve_final_output(self, final_output: Any) -> OutSchema:

--- a/akd_ext/agents/_mixins.py
+++ b/akd_ext/agents/_mixins.py
@@ -35,6 +35,10 @@ class FileAttachmentMixin:
         if not attachments:
             return
 
+        if not messages:
+            run_context.messages = [{"role": "user", "content": []}]
+            messages = run_context.messages
+
         # Find last user message and convert to multipart content array
         for msg in reversed(messages):
             if msg.get("role") == "user":

--- a/akd_ext/agents/_mixins.py
+++ b/akd_ext/agents/_mixins.py
@@ -35,9 +35,8 @@ class FileAttachmentMixin:
         if not attachments:
             return
 
-        if not messages:
-            run_context.messages = [{"role": "user", "content": []}]
-            messages = run_context.messages
+        run_context.messages = messages or [{"role": "user", "content": []}]
+        messages = run_context.messages
 
         # Find last user message and convert to multipart content array
         for msg in reversed(messages):

--- a/akd_ext/files.py
+++ b/akd_ext/files.py
@@ -46,7 +46,7 @@ class OpenAIFileResolver:
     """Passes file_id natively to OpenAI — no fetching needed."""
 
     async def resolve(self, attachment: OpenAIFileAttachment) -> list[dict[str, Any]]:
-        return [{"type": "file", "file": {"file_id": attachment.openai_file_id}}]
+        return [{"type": "input_file", "file_id": attachment.openai_file_id}]
 
 
 class URLFileResolver:


### PR DESCRIPTION
## Summary

Fixes a `BadRequestError` when attaching files to agents using the OpenAI API by correcting the file content block type and wiring file attachment resolution into the `astream` lifecycle.

## What it does

- Fixes the OpenAI file resolver to emit the correct content block schema (`input_file` instead of `file`), resolving the `BadRequestError` from the API.
- Adds an `astream` override in `OpenAIBaseAgent` so that file attachments are resolved and injected into messages before the LLM call during streaming.
- Adds a guard in `FileAttachmentMixin._resolve_and_inject_files` to handle the edge case where the messages list is empty.

## How it does this

1. **`akd_ext/files.py`** — Changes the `OpenAIFileResolver.resolve()` return from `{"type": "file", "file": {"file_id": ...}}` to `{"type": "input_file", "file_id": ...}` to match the OpenAI API's expected schema.
2. **`akd_ext/agents/_base.py`** — Adds an `astream()` override that calls `_resolve_and_inject_files()` before delegating to `super().astream()`, ensuring file context is injected during streaming runs.
3. **`akd_ext/agents/_mixins.py`** — Adds a guard clause in `_resolve_and_inject_files()` to initialize `run_context.messages` with a default user message when the messages list is empty, preventing index errors.

## Files changed

| File | Change |
|------|--------|
| `akd_ext/files.py` | Fix content block type from `file` to `input_file` |
| `akd_ext/agents/_base.py` | Add `astream()` override with file injection |
| `akd_ext/agents/_mixins.py` | Add empty-messages guard in `_resolve_and_inject_files` |

## Testing

- Verified that file attachments now pass OpenAI API validation during `astream` calls.
- Existing unit tests in `tests/test_file_attachment_mixin.py` and `tests/test_files.py` cover resolver and mixin behavior.
