### PR TITLE
Remove redundant use of messages in the FileAttachmentMixin

### DIFF
--- a/akd_ext/agents/_base.py
+++ b/akd_ext/agents/_base.py
@@ -459,7 +459,7 @@ class OpenAIBaseAgent[InSchema: InputSchema, OutSchema: OutputSchema](
         - Tool/union mode: consumes _run_engine_stream() watching for CompletedEvent
         """
         # Resolve and inject file attachments before LLM call
-        await self._resolve_and_inject_files(run_context.messages, run_context)
+        await self._resolve_and_inject_files(run_context)
 
         has_union = len(self.output_schema_resolved) > 1
         use_tool_loop = bool(self.config.tools) or (has_union and self.output_mode == "multi_tool")
@@ -484,7 +484,7 @@ class OpenAIBaseAgent[InSchema: InputSchema, OutSchema: OutputSchema](
         **kwargs: Any,
     ) -> AsyncIterator[StreamEvent]:
         # Resolve and inject file attachments before LLM call
-        await self._resolve_and_inject_files(run_context.messages, run_context)
+        await self._resolve_and_inject_files(run_context)
         async for event in super().astream(params=params, run_context=run_context, **kwargs):
             yield event
 

--- a/akd_ext/agents/_mixins.py
+++ b/akd_ext/agents/_mixins.py
@@ -27,16 +27,14 @@ class FileAttachmentMixin:
 
     async def _resolve_and_inject_files(
         self,
-        messages: list[dict[str, Any]],
         run_context: RunContext,
     ) -> None:
         """Resolve file attachments and inject content into the last user message."""
         attachments: list[FileAttachment] = getattr(run_context, "file_attachments", [])
-        if not attachments:
+        if not attachments or not run_context:
             return
 
-        run_context.messages = messages or [{"role": "user", "content": []}]
-        messages = run_context.messages
+        messages: list[dict[str, Any]] = run_context.messages or [{"role": "user", "content": []}]
 
         # Find last user message and convert to multipart content array
         for msg in reversed(messages):
@@ -50,3 +48,5 @@ class FileAttachmentMixin:
                     parts.extend(await resolver.resolve(att))
                 msg["content"] = parts
                 break
+
+        run_context.messages = messages


### PR DESCRIPTION
## Changes
Ensures that _resolve_and_inject_files no longer accepts a separate messages list, instead reading directly from run_context.messages. This prevents the caller from passing a potentially stale or duplicate reference and ensures run_context.messages is only updated at the end, after all file content has been resolved and injected.

## Testing
Verified that file attachments are correctly resolved and injected into user messages.
Confirmed that run_context.messages is no longer mutated prematurely before resolution completes.
