### PR TITLE
fix: use correct content block type for image URL resolver

### DIFF
--- a/akd_ext/files.py
+++ b/akd_ext/files.py
@@ -74,8 +74,8 @@ class URLFileResolver:
             encoded = base64.b64encode(raw).decode("utf-8")
             return [
                 {
-                    "type": "image_url",
-                    "image_url": {"url": f"data:{attachment.mime_type};base64,{encoded}"},
+                    "type": "input_image",
+                    "image_url": f"data:{attachment.mime_type};base64,{encoded}",
                 }
             ]
 


### PR DESCRIPTION
## Summary
Updates the `URLFileResolver` to use the correct content block type and structure for image attachments, aligning with the expected API schema.

## What it does
Changes the image content block type from `"image_url"` to `"input_image"` and simplifies the `image_url` value from a nested object to a plain data URI string.

## How it does this
In `URLFileResolver`, the base64-encoded image return block is updated:
- `"type": "image_url"` → `"type": "input_image"`
- `"image_url": {"url": f"data:..."}` → `"image_url": f"data:..."`

This removes the unnecessary nested `{"url": ...}` wrapper and uses the correct type identifier.

## Files changed
- [akd_ext/files.py](cci:7://file:///Users/thapa24-mbp/Devs/akd/akd-ext/akd_ext/files.py:0:0-0:0) — Updated the image content block structure in `URLFileResolver`

## Testing
- Verified image file attachments resolve correctly with the updated block format
