### PR TITLE
feat: add image URL and filename context to uploaded images

### DIFF
--- a/akd_ext/files.py
+++ b/akd_ext/files.py
@@ -76,7 +76,12 @@ class URLFileResolver:
                 {
                     "type": "input_image",
                     "image_url": f"data:{attachment.mime_type};base64,{encoded}",
-                }
+                },
+                # caption to the image.
+                {
+                    "type": "input_text",
+                    "text": f"caption to the image above: [Image: {attachment.filename}] (url: {attachment.url})",
+                },
             ]
 
         # Text-based files


### PR DESCRIPTION
## Summary
Enhances the file resolution process to provide the LLM with relevant source information (filename and URL) for uploaded images in addition to the base64 image data.

## What it does
This PR updates the `URLFileResolver` to include an additional text block containing the image's filename and URL context immediately following its `input_image` block. 

## How it does this
By appending an `input_text` format response block—`{"type": "input_text", "text": "caption to the image above: [Image: {attachment.filename}] (url: {attachment.url})"}`—directly after the image is encoded as a base64 dictionary within [akd_ext/files.py](cci:7://file:///Users/thapa24-mbp/Devs/akd/akd-ext/.worktrees/enhance-image_upload-add_link_context/akd_ext/files.py:0:0-0:0).

## Testing
- Verified that images resolved by the `URLFileResolver` correctly append the context string.
- (Recommended) Ensure no schema validation errors are thrown when submitting the input message list to the underlying Agent/OpenAI APIs.
