### PR TITLE
feat: Add descriptions to CM1 closed loop agents

### DIFF
--- a/akd_ext/agents/closed_loop_cm1/capability_feasibility_mapper.py
+++ b/akd_ext/agents/closed_loop_cm1/capability_feasibility_mapper.py
@@ -376,6 +376,12 @@ class CapabilityFeasibilityMapperConfig(OpenAIBaseAgentConfig):
     )
     model_name: str = Field(default="gpt-5.2")
     reasoning_effort: Literal["low", "medium", "high"] | None = Field(default="medium")
+    description: str = Field(
+        default="Research-analysis agent that evaluates whether research questions and hypotheses can be "
+        "realistically tested using available numerical models (CM1, WRF, HWRF, OLAM), codebases, and "
+        "cluster resources. Produces structured capability-feasibility assessment reports with evidence "
+        "paths and capability vs feasibility matrices."
+    )
 
 
 # -----------------------------------------------------------------------------

--- a/akd_ext/agents/closed_loop_cm1/capability_feasibility_mapper.py
+++ b/akd_ext/agents/closed_loop_cm1/capability_feasibility_mapper.py
@@ -380,7 +380,8 @@ class CapabilityFeasibilityMapperConfig(OpenAIBaseAgentConfig):
         default="Research-analysis agent that evaluates whether research questions and hypotheses can be "
         "realistically tested using available numerical models (CM1, WRF, HWRF, OLAM), codebases, and "
         "cluster resources. Produces structured capability-feasibility assessment reports with evidence "
-        "paths and capability vs feasibility matrices."
+        "paths and capability vs feasibility matrices. May also produce free-form text responses to "
+        "chat with the user for clarification, approval gates, or status updates."
     )
 
 

--- a/akd_ext/agents/closed_loop_cm1/experiment_implementation.py
+++ b/akd_ext/agents/closed_loop_cm1/experiment_implementation.py
@@ -226,6 +226,12 @@ class ExperimentImplementationConfig(OpenAIBaseAgentConfig):
     model_name: str = Field(default="gpt-5.2")
     reasoning_effort: Literal["low", "medium", "high"] | None = Field(default="medium")
     tools: list[Any] = Field(default_factory=get_default_impl_tools)
+    description: str = Field(
+        default="Stage-4A implementation planner that translates Stage-3 workflow specs into structured "
+        "FileEdit JSON and submits experiment batches as jobs via MCP tool calls. Produces deterministic "
+        "edit definitions (namelist_param, sounding_profile, file_replace) without directly creating files "
+        "or executing commands."
+    )
 
 
 # -----------------------------------------------------------------------------

--- a/akd_ext/agents/closed_loop_cm1/experiment_implementation.py
+++ b/akd_ext/agents/closed_loop_cm1/experiment_implementation.py
@@ -230,7 +230,8 @@ class ExperimentImplementationConfig(OpenAIBaseAgentConfig):
         default="Stage-4A implementation planner that translates Stage-3 workflow specs into structured "
         "FileEdit JSON and submits experiment batches as jobs via MCP tool calls. Produces deterministic "
         "edit definitions (namelist_param, sounding_profile, file_replace) without directly creating files "
-        "or executing commands."
+        "or executing commands. May also produce free-form text responses to chat with the user for "
+        "clarification, approval gates, or status updates."
     )
 
 

--- a/akd_ext/agents/closed_loop_cm1/interpretation_paper_assembly.py
+++ b/akd_ext/agents/closed_loop_cm1/interpretation_paper_assembly.py
@@ -427,7 +427,9 @@ class InterpretationPaperAssemblyConfig(OpenAIBaseAgentConfig):
     description: str = Field(
         default="Stage-5 interpretation and paper assembly agent that transforms CM1 atmospheric model "
         "experiment outputs into structured scientific analysis artifacts including YAML manifests, "
-        "executable Jupyter analysis notebooks, and publication-style Markdown reports with matplotlib figures."
+        "executable Jupyter analysis notebooks, and publication-style Markdown reports with matplotlib figures. "
+        "May also produce free-form text responses to chat with the user for clarification, approval gates, "
+        "or status updates."
     )
 
 

--- a/akd_ext/agents/closed_loop_cm1/interpretation_paper_assembly.py
+++ b/akd_ext/agents/closed_loop_cm1/interpretation_paper_assembly.py
@@ -424,6 +424,11 @@ class InterpretationPaperAssemblyConfig(OpenAIBaseAgentConfig):
     system_prompt: str = Field(default=INTERPRETATION_PAPER_ASSEMBLY_SYSTEM_PROMPT)
     model_name: str = Field(default="gpt-5.2")
     reasoning_effort: Literal["low", "medium", "high"] | None = Field(default="medium")
+    description: str = Field(
+        default="Stage-5 interpretation and paper assembly agent that transforms CM1 atmospheric model "
+        "experiment outputs into structured scientific analysis artifacts including YAML manifests, "
+        "executable Jupyter analysis notebooks, and publication-style Markdown reports with matplotlib figures."
+    )
 
 
 # -----------------------------------------------------------------------------

--- a/akd_ext/agents/closed_loop_cm1/research_report_generator.py
+++ b/akd_ext/agents/closed_loop_cm1/research_report_generator.py
@@ -11,6 +11,7 @@ Public API:
     ResearchReportGeneratorOutputSchema,
     ResearchReportGeneratorConfig
 """
+
 from __future__ import annotations
 
 import os
@@ -236,6 +237,11 @@ class ResearchReportGeneratorConfig(OpenAIBaseAgentConfig):
     model_name: str = Field(default="gpt-5.2")
     reasoning_effort: Literal["low", "medium", "high"] | None = Field(default="medium")
     tools: list[Any] = Field(default_factory=get_default_report_tools)
+    description: str = Field(
+        default="Stage-5 report generator that produces publication-style scientific reports interpreting "
+        "CM1 experiment results. Checks job status via MCP tools, fetches figure URLs, and generates "
+        "Markdown reports with Abstract, Methodology, Results, Discussion, and Conclusion sections."
+    )
 
 
 # -----------------------------------------------------------------------------

--- a/akd_ext/agents/closed_loop_cm1/research_report_generator.py
+++ b/akd_ext/agents/closed_loop_cm1/research_report_generator.py
@@ -240,7 +240,9 @@ class ResearchReportGeneratorConfig(OpenAIBaseAgentConfig):
     description: str = Field(
         default="Stage-5 report generator that produces publication-style scientific reports interpreting "
         "CM1 experiment results. Checks job status via MCP tools, fetches figure URLs, and generates "
-        "Markdown reports with Abstract, Methodology, Results, Discussion, and Conclusion sections."
+        "Markdown reports with Abstract, Methodology, Results, Discussion, and Conclusion sections. "
+        "May also produce free-form text responses to chat with the user for clarification, approval gates, "
+        "or status updates."
     )
 
 

--- a/akd_ext/agents/closed_loop_cm1/workflow_spec_builder.py
+++ b/akd_ext/agents/closed_loop_cm1/workflow_spec_builder.py
@@ -186,7 +186,8 @@ class WorkflowSpecBuilderConfig(OpenAIBaseAgentConfig):
         default="Stage-3 experiment design agent that converts research questions into scientifically "
         "traceable, feasibility-aware simulation workflow specifications for CM1 or WRF. Proposes "
         "baseline plus perturbation experiments, parameter sweeps, and namelist changes as execution-ready "
-        "Markdown documents."
+        "Markdown documents. May also produce free-form text responses to chat with the user for "
+        "clarification, approval gates, or status updates."
     )
 
 

--- a/akd_ext/agents/closed_loop_cm1/workflow_spec_builder.py
+++ b/akd_ext/agents/closed_loop_cm1/workflow_spec_builder.py
@@ -182,6 +182,12 @@ class WorkflowSpecBuilderConfig(OpenAIBaseAgentConfig):
     )
     model_name: str = Field(default="gpt-5.2")
     reasoning_effort: Literal["low", "medium", "high"] | None = Field(default="medium")
+    description: str = Field(
+        default="Stage-3 experiment design agent that converts research questions into scientifically "
+        "traceable, feasibility-aware simulation workflow specifications for CM1 or WRF. Proposes "
+        "baseline plus perturbation experiments, parameter sweeps, and namelist changes as execution-ready "
+        "Markdown documents."
+    )
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
This PR adds descriptive summaries to the configuration classes of all closed loop CM1 agents, detailing their roles and responsibilities within the research workflow.

## What it does
Provides better context, observability, and documentation on the exact function each agent serves by adding a detailed `description` field to their configurations. These descriptions cover the specific stages of the workflow: capability mapping, experiment design, experiment implementation, analysis/paper assembly, and report generation. 

## How it does this
By adding a default `description` string to the Pydantic configuration models (`OpenAIBaseAgentConfig` subclasses) for the following agents:
- `CapabilityFeasibilityMapperConfig`
- `WorkflowSpecBuilderConfig`
- `ExperimentImplementationConfig`
- `InterpretationPaperAssemblyConfig`
- `ResearchReportGeneratorConfig`

## Testing
- Verified that the syntax is correct and the Pydantic models initialize correctly with the new `description` default fields.
- (Note: No logical workflow changes were introduced, primarily schema documentation.)
