### PR TITLE
feat: Add message truncation support to OpenAIBaseAgentConfig

### DIFF
--- a/akd_ext/agents/_base.py
+++ b/akd_ext/agents/_base.py
@@ -101,6 +101,10 @@ class OpenAIBaseAgentConfig(BaseAgentConfig):
     top_p: float | None = Field(default=None, description="Nucleus sampling parameter.")
     frequency_penalty: float | None = Field(default=None, description="Frequency penalty for token repetition.")
     presence_penalty: float | None = Field(default=None, description="Presence penalty for new topics.")
+    truncation: Literal["auto", "disabled"] | None = Field(
+        default="auto",
+        description="Truncation strategy for managing context window. 'auto' enables server-side truncation of older messages.",
+    )
 
     @field_validator("tools", mode="before")
     @classmethod
@@ -135,6 +139,7 @@ class OpenAIBaseAgentConfig(BaseAgentConfig):
                 store=True,
                 max_tokens=self.max_tokens,
                 reasoning=reasoning,
+                truncation=self.truncation,
             )
         # Non-reasoning models use standard sampling parameters
         return ModelSettings(
@@ -144,6 +149,7 @@ class OpenAIBaseAgentConfig(BaseAgentConfig):
             top_p=self.top_p,
             frequency_penalty=self.frequency_penalty,
             presence_penalty=self.presence_penalty,
+            truncation=self.truncation,
         )
 
     @property


### PR DESCRIPTION
## Summary

Referring from https://github.com/NASA-IMPACT/akd-labs/pull/38 Adds a configurable `truncation` parameter to [OpenAIBaseAgentConfig](cci:2://file:///Users/thapa24-mbp/Devs/akd/akd-ext/.worktrees/feature-message_truncate/akd_ext/agents/_base.py:67:0-157:66), enabling server-side context window management for OpenAI agents. Defaults to `"auto"` so older messages are automatically truncated when the context window fills up.

## What it does

- Introduces a new `truncation` field on [OpenAIBaseAgentConfig](cci:2://file:///Users/thapa24-mbp/Devs/akd/akd-ext/.worktrees/feature-message_truncate/akd_ext/agents/_base.py:67:0-157:66) with options `"auto"`, `"disabled"`, or `None`.
- Passes the `truncation` setting through to `ModelSettings` for both reasoning and non-reasoning model paths.
- Defaults to `"auto"`, which enables the OpenAI API to automatically drop older messages when the conversation exceeds the model's context window.

## How it does this

- Adds a `truncation: Literal["auto", "disabled"] | None` Pydantic field to [OpenAIBaseAgentConfig](cci:2://file:///Users/thapa24-mbp/Devs/akd/akd-ext/.worktrees/feature-message_truncate/akd_ext/agents/_base.py:67:0-157:66) with a default of `"auto"`.
- Updates the [model_settings](cci:1://file:///Users/thapa24-mbp/Devs/akd/akd-ext/.worktrees/feature-message_truncate/akd_ext/agents/_base.py:122:4-152:9) property to include `truncation=self.truncation` in both the reasoning model `ModelSettings` (alongside `store`, `max_tokens`, `reasoning`) and the non-reasoning model `ModelSettings` (alongside `store`, `temperature`, `max_tokens`, `top_p`, `frequency_penalty`, `presence_penalty`).

## Files changed

- [akd_ext/agents/_base.py](cci:7://file:///Users/thapa24-mbp/Devs/akd/akd-ext/.worktrees/feature-message_truncate/akd_ext/agents/_base.py:0:0-0:0) — Added `truncation` field to [OpenAIBaseAgentConfig](cci:2://file:///Users/thapa24-mbp/Devs/akd/akd-ext/.worktrees/feature-message_truncate/akd_ext/agents/_base.py:67:0-157:66) and wired it into both `ModelSettings` construction paths.

## Testing

- Existing unit tests in `tests/agents/` validate agent config and behavior.
- The new field uses a safe default (`"auto"`) and is a pass-through to the OpenAI SDK's `ModelSettings`, requiring no additional logic testing.
