### PR TITLE
fix: use enriched _system_prompt in OpenAI agent creation and simplify output schemas

### DIFF
--- a/akd_ext/agents/_base.py
+++ b/akd_ext/agents/_base.py
@@ -208,7 +208,7 @@ class OpenAIBaseAgent[InSchema: InputSchema, OutSchema: OutputSchema](
         if not is_union:
             return Agent(
                 name=self.__class__.__name__,
-                instructions=self.config.system_prompt,
+                instructions=self._system_prompt,
                 model=self.config.model_name or "gpt-5-nano",
                 tools=self.config.tools,
                 output_type=None if is_text else self.output_schema,
@@ -219,7 +219,7 @@ class OpenAIBaseAgent[InSchema: InputSchema, OutSchema: OutputSchema](
             envelope = self.effective_output_schema
             return Agent(
                 name=self.__class__.__name__,
-                instructions=self.config.system_prompt,
+                instructions=self._system_prompt,
                 model=self.config.model_name or "gpt-5-nano",
                 tools=self.config.tools,
                 output_type=envelope,
@@ -232,7 +232,7 @@ class OpenAIBaseAgent[InSchema: InputSchema, OutSchema: OutputSchema](
         all_tools = list(self.config.tools) + sdk_output_tools
         return Agent(
             name=self.__class__.__name__,
-            instructions=self.config.system_prompt,
+            instructions=self._system_prompt,
             model=self.config.model_name or "gpt-5-nano",
             tools=all_tools,
             output_type=None,

--- a/akd_ext/agents/cmr_care.py
+++ b/akd_ext/agents/cmr_care.py
@@ -58,10 +58,10 @@ CMR_DATA_SEARCH_CARE_AGENT_SYSTEM_PROMPT = """ROLE
     You accept:
     A free-text science question
     An explicitly selected user expertise level (Intermediate / Advanced)
-    You may use only the following tools and data sources along with the attached context documents:
+    You may use only the following tools and data sources along with the attached context documents: 
     NASA CMR Search API (REST) — collection discovery only
     GCMD Keyword Management System (KMS) — vocabulary mapping only
-    Semantic Scholar API — optional, user-approved indirect discovery only
+    Semantic Scholar API — optional, user-approved indirect discovery only 
     Google Scholar as a last resort.
     Earthdata Search Web App — link handoff only (no API calls)
 
@@ -104,18 +104,13 @@ CMR_DATA_SEARCH_CARE_AGENT_SYSTEM_PROMPT = """ROLE
     Exclude variables that cannot map to GCMD
     Obtain explicit user approval
     Re-run the entire loop
-    If scope is non-Earth science → respond "I don't know" and stop.
-    If user direcly wants to get the data, the provided queries are self sufficient and does not need human approval (already human verified))
+    If scope is non-Earth science → respond “I don’t know” and stop.
 
 
     OUTPUT FORMAT
     All responses must follow this structure exactly. No free-form text is allowed outside these sections.
-    When using markdown headings, always include a space after the # characters (e.g., "## 1. Section Title" not "##1. Section Title").
     1. Clarifying Questions
-    Included only when required inputs are missing
-    Blocking; no continuation until answered
-    Always ask the human directly for clarification rather than listing questions in your output
-    ≤ 5 questions
+    You must ask clarifying questions to the user to reduce ambiquity in search.
     2. Interpreted Scope
     Restate user intent without inference
     Separate confirmed inputs vs unresolved ambiguities
@@ -150,9 +145,8 @@ CMR_DATA_SEARCH_CARE_AGENT_SYSTEM_PROMPT = """ROLE
 
 
     STOP / DEGRADED OUTPUT
-    If blocked due to missing inputs or ambiguity, always ask the human for clarification before stopping.
-    If no human input mechanism is available, output only:
-    "Here's what I cannot determine and what I need from you."
+    If blocked due to missing inputs, ambiguity, or tool failure, output only:
+    “Here’s what I cannot determine and what I need from you.”
     Then list:
     What cannot be determined
     Why
@@ -214,8 +208,7 @@ CMR_DATA_SEARCH_CARE_AGENT_SYSTEM_PROMPT = """ROLE
     ### Example
     ```bash
     # Using Authorization header
-    curl -H "Authorization: Bearer YOUR_TOKEN" \\
-    "https://cmr.earthdata.nasa.gov/search/collections"
+    curl -H "Authorization: Bearer YOUR_TOKEN"   "https://cmr.earthdata.nasa.gov/search/collections"
 
     # Using token parameter
     curl "https://cmr.earthdata.nasa.gov/search/collections?token=YOUR_TOKEN"
@@ -399,7 +392,7 @@ CMR_DATA_SEARCH_CARE_AGENT_SYSTEM_PROMPT = """ROLE
 
     - **CMR Documentation**: https://cmr.earthdata.nasa.gov/search/site/docs/search/api.html
     - **UMM Specification**: https://earthdata.nasa.gov/eosdis/science-system-description/eosdis-components/common-metadata-repository
-    """
+"""
 
 
 # -----------------------------------------------------------------------------
@@ -469,11 +462,8 @@ class CMRCareAgentOutputSchema(OutputSchema):
     Put ALL your text output (interpreted scope, dataset list, reproducibility log, tables, JSON audit block) in the report field.
     Use TextOutput for clarification questions or when no datasets were found."""
 
-    __response_field__ = "report"
-    dataset_concept_ids: list[str] = Field(..., description="List of CMR dataset concept IDs found")
-    report: str = Field(
-        default="", description="Full structured report including all sections, tables, and JSON audit block"
-    )
+    __response_field__ = "result"
+    result: str = Field(..., description="Search result with discovered CMR datasets and details")
 
 
 # -----------------------------------------------------------------------------

--- a/akd_ext/agents/cmr_care.py
+++ b/akd_ext/agents/cmr_care.py
@@ -104,7 +104,7 @@ CMR_DATA_SEARCH_CARE_AGENT_SYSTEM_PROMPT = """ROLE
     Exclude variables that cannot map to GCMD
     Obtain explicit user approval
     Re-run the entire loop
-    If scope is non-Earth science → respond “I don’t know” and stop.
+    If scope is non-Earth science → respond "I'm sorry, this query falls outside my area of expertise in Earth science data discovery. I'm unable to assist with this request." and stop.
 
 
     OUTPUT FORMAT

--- a/akd_ext/agents/code_search_care.py
+++ b/akd_ext/agents/code_search_care.py
@@ -352,9 +352,8 @@ class Repository(BaseModel):
 class CodeSearchCareAgentOutputSchema(OutputSchema):
     """Output schema for CODE SEARCH Agent."""
 
-    __response_field__ = "report"
-    repositories: list[Repository] = Field(..., description="List of relevant repositories")
-    report: str = Field(default="", description="Detailed report with reasoning")
+    __response_field__ = "result"
+    result: str = Field(..., description="Search result with discovered code repository and details")
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes a bug where `_create_agent()` was using `config.system_prompt` (raw) instead of the enriched `_system_prompt` (which includes output schema field hints), causing the LLM to miss critical output field descriptions. Also simplifies the output schemas for CMR and Code Search agents and syncs the CMR agent prompt with the alpha environment.

## What it does

- Ensures the OpenAI agent receives the fully enriched system prompt that includes output schema hints appended by `_build_system_prompt()`
- Simplifies `CMRCareAgentOutputSchema` and `CodeSearchCareAgentOutputSchema` to use a single `result` string field instead of multiple structured fields
- Updates the CMR CARE agent system prompt to align with the alpha deployment

## How it does this

- **`_base.py`**: Replaces `self.config.system_prompt` with `self._system_prompt` in all three `Agent(...)` constructor calls inside `_create_agent()` (non-union, union/envelope, and SDK-output-tool branches). `_system_prompt` is the property that appends output field descriptions to the base prompt via `_build_system_prompt()`.
- **`cmr_care.py`**: Simplifies `CMRCareAgentOutputSchema` by replacing `dataset_concept_ids` (list) + `report` (str) with a single `result` field. Updates `__response_field__` from `"report"` to `"result"`. Syncs the system prompt text with the alpha environment (clarifying question behavior, stop/degraded output wording, formatting fixes).
- **`code_search_care.py`**: Simplifies `CodeSearchCareAgentOutputSchema` by replacing `repositories` (list) + `report` (str) with a single `result` field. Updates `__response_field__` from `"report"` to `"result"`.

## Files changed

| File | Change |
|------|--------|
| [akd_ext/agents/_base.py](cci:7://file:///Users/thapa24-mbp/Devs/akd/akd-ext/.worktrees/fix-unified_output_schema_prompt_precedence/akd_ext/agents/_base.py:0:0-0:0) | Use `self._system_prompt` instead of `self.config.system_prompt` in all `Agent()` calls |
| [akd_ext/agents/cmr_care.py](cci:7://file:///Users/thapa24-mbp/Devs/akd/akd-ext/.worktrees/fix-unified_output_schema_prompt_precedence/akd_ext/agents/cmr_care.py:0:0-0:0) | Simplify output schema to single `result` field; sync system prompt with alpha |
| [akd_ext/agents/code_search_care.py](cci:7://file:///Users/thapa24-mbp/Devs/akd/akd-ext/.worktrees/fix-unified_output_schema_prompt_precedence/akd_ext/agents/code_search_care.py:0:0-0:0) | Simplify output schema to single `result` field |

## Testing

- Verified that `_system_prompt` correctly includes appended output field descriptions
- Confirmed agent creation uses the enriched prompt in all code paths (
****