### PR TITLE
Fix stale tests: file resolver + workflow spec builder schemas

### DIFF
--- a/tests/agents/research_partner/test_workflow_spec_builder.py
+++ b/tests/agents/research_partner/test_workflow_spec_builder.py
@@ -11,10 +11,20 @@ from akd_ext.agents.closed_loop_cm1 import (
 )
 
 
+_DEFAULT_FEASIBILITY = (
+    "# Feasibility Report\n\n"
+    "**Model**: CM1\n"
+    "**Capability score**: 0.85 (high)\n\n"
+    "The proposed experiment is feasible with the chosen model. "
+    "Required parameters are available in the model configuration."
+)
+
+
 def _make_input(**overrides) -> WorkflowSpecBuilderInputSchema:
     """Helper to create input schema with default placeholder values."""
     defaults = {
         "stage_1_hypotheses": "RQ-001: Does increasing surface roughness length affect boundary layer depth?",
+        "stage_2_feasibility": _DEFAULT_FEASIBILITY,
     }
     defaults.update(overrides)
     return WorkflowSpecBuilderInputSchema(**defaults)
@@ -22,33 +32,18 @@ def _make_input(**overrides) -> WorkflowSpecBuilderInputSchema:
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "stage_1_hypotheses,model_name",
+    "stage_1_hypotheses",
     [
-        (
-            "RQ-001: Does increasing surface roughness length affect boundary layer depth in tropical cyclones?",
-            "CM1",
-        ),
-        (
-            "RQ-001: How does SST perturbation influence convective initiation timing?",
-            "CM1",
-        ),
-        (
-            "RQ-001: What is the sensitivity of precipitation to microphysics scheme choice?",
-            "WRF",
-        ),
+        "RQ-001: Does increasing surface roughness length affect boundary layer depth in tropical cyclones?",
+        "RQ-001: How does SST perturbation influence convective initiation timing?",
+        "RQ-001: What is the sensitivity of precipitation to microphysics scheme choice?",
     ],
 )
-async def test_workflow_spec_builder_agent(stage_1_hypotheses: str, model_name: str, reasoning_effort: str):
-    """Test Workflow Spec Builder Agent.
-
-    Args:
-        stage_1_hypotheses: Stage-1 hypotheses artifact
-        model_name: Target model
-        reasoning_effort: CLI param --reasoning-effort (low/medium/high)
-    """
+async def test_workflow_spec_builder_agent(stage_1_hypotheses: str, reasoning_effort: str):
+    """Test Workflow Spec Builder Agent."""
     config = WorkflowSpecBuilderConfig(reasoning_effort=reasoning_effort)
     agent = WorkflowSpecBuilderAgent(config=config, debug=True)
-    result = await agent.arun(_make_input(stage_1_hypotheses=stage_1_hypotheses, model_name=model_name))
+    result = await agent.arun(_make_input(stage_1_hypotheses=stage_1_hypotheses))
 
     assert isinstance(result, (WorkflowSpecBuilderOutputSchema, TextOutput))
     if isinstance(result, WorkflowSpecBuilderOutputSchema):

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -80,7 +80,7 @@ class TestURLFileResolver:
         parts = await resolver.resolve(att)
 
         assert len(parts) == 1
-        assert parts[0]["type"] == "text"
+        assert parts[0]["type"] == "input_text"
         assert "[File: data.csv]" in parts[0]["text"]
         assert "col1,col2" in parts[0]["text"]
         resolver._fetch.assert_awaited_once_with("https://example.com/data.csv")
@@ -97,10 +97,12 @@ class TestURLFileResolver:
         )
         parts = await resolver.resolve(att)
 
-        assert len(parts) == 1
+        assert len(parts) == 2
         assert parts[0]["type"] == "input_image"
         expected_b64 = base64.b64encode(image_bytes).decode("utf-8")
         assert parts[0]["image_url"] == f"data:image/png;base64,{expected_b64}"
+        assert parts[1]["type"] == "input_text"
+        assert "img.png" in parts[1]["text"]
 
     @pytest.mark.asyncio
     async def test_resolve_with_custom_client(self):
@@ -113,7 +115,7 @@ class TestURLFileResolver:
         )
         parts = await resolver.resolve(att)
 
-        assert parts[0]["type"] == "text"
+        assert parts[0]["type"] == "input_text"
         assert "hello" in parts[0]["text"]
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- `test_files.py`: URLFileResolver emits `input_text`/`input_image` types (OpenAI Responses API format). Tests still expected the old `text` type. Updated to match.
- `test_files.py`: Image resolve now returns 2 parts (image + caption text). Updated assertion to `len(parts) == 2`.
- `test_workflow_spec_builder.py`: `WorkflowSpecBuilderInputSchema` requires `stage_2_feasibility` — test didn't pass it. Added a realistic default. Also dropped the obsolete `model_name` parametrize which isn't on the schema anymore.

## Test plan
- [x] `uv run pytest tests/test_files.py` — 11 passed
- [x] `uv run pytest "tests/agents/research_partner/test_workflow_spec_builder.py::test_workflow_spec_builder_agent[RQ-001: Does increasing surface roughness length affect boundary layer depth in tropical cyclones?]"` — passes (real LLM call, 24s)