### PR TITLE
Fix stale queries in repository search tests

### DIFF
--- a/tests/tools/code_search/test_repository_search.py
+++ b/tests/tools/code_search/test_repository_search.py
@@ -15,8 +15,8 @@ class TestRepositorySearchTool:
     @pytest.mark.parametrize(
         "query",
         [
-            "indus pipeline code",
-            "NASA earth science data processing for universal file format",
+            "nasa python",
+            "pds software",
         ],
     )
     async def test_repository_search_tool(self, query: str):
@@ -55,5 +55,6 @@ class TestRepositorySearchTool:
         """Test Repository Search Tool results number."""
         config = RepositorySearchToolConfig(page_size=page_size)
         tool = RepositorySearchTool(config=config)
-        result = await tool.arun(RepositorySearchToolInputSchema(queries=["indus pipeline code"]))
+        # "nasa python" has >100 results in the SDE code index so any page_size up to the 10 cap works
+        result = await tool.arun(RepositorySearchToolInputSchema(queries=["nasa python"]))
         assert len(result.results) == result_size


### PR DESCRIPTION
## Summary
Fix stale queries in `tests/tools/code_search/test_repository_search.py` — the old queries (`"indus pipeline code"`, `"NASA earth science data processing for universal file format"`) return 0 results from SDE's `/api/code/search` endpoint. Switched to queries that actually have content in the code index.

## Why it was failing
Verified directly against SDE API (`https://d2kqty7z3q8ugg.cloudfront.net/api/code/search`):
- `"indus pipeline code"` → 0 documents
- `"nasa"` → 861 documents
- `"nasa python"` → sufficient for all page_size parametrizations
- `"pds software"` → 5+ documents

The tool is working correctly — the test queries were just stale.

## Changes
- `test_repository_search_tool`: queries → `"nasa python"`, `"pds software"`
- `test_repository_search_tool_results_number`: query → `"nasa python"`

## Test plan
- [x] `uv run pytest tests/tools/code_search/test_repository_search.py` — 8 passed