### PR TITLE
Add LocalArtifactStore + supported_extensions filter

### DIFF
--- a/akd_ext/artifacts/_base.py
+++ b/akd_ext/artifacts/_base.py
@@ -5,6 +5,8 @@ from typing import Any, Self
 
 from pydantic import BaseModel, Field, field_validator
 
+from akd_ext.artifacts.utils import canonical_ext
+
 
 class Artifact[T](BaseModel):
     path: str = Field(..., description="Slug that identifies the artifact.")
@@ -72,12 +74,21 @@ class ArtifactStore[T](ABC):
         root: str,
         *,
         index_file: str | None = "index.md",
+        supported_extensions: tuple[str, ...] = (".md",),
         debug: bool = False,
     ) -> None:
         self.root = root
         self.index_file = index_file
+        self.supported_extensions = tuple(map(canonical_ext, supported_extensions))
         self.debug = bool(debug)
         self._artifacts: dict[str, Artifact[T]] = {}
+
+    def _is_supported(self, path: str) -> bool:
+        """True if `path`'s extension is in `self.supported_extensions`.
+        An empty `supported_extensions` disables filtering."""
+        if not self.supported_extensions:
+            return True
+        return PurePosixPath(path).suffix in self.supported_extensions
 
     def index_for(self, dir_path: str = "") -> Artifact[T] | None:
         """Return the designated index artifact for a directory (or the

--- a/akd_ext/artifacts/stores/local.py
+++ b/akd_ext/artifacts/stores/local.py
@@ -104,3 +104,23 @@ class LocalArtifactStore(ArtifactStore[str]):
         )
         self[path] = artifact
         return artifact
+
+    async def write_artifact(self, artifact: Artifact[str]) -> Artifact[str]:
+        """Persist an artifact to disk.
+
+        Args:
+            artifact: Artifact to write. Its content is saved as UTF-8 text
+                at the artifact's `path`.
+
+        Returns:
+            The stored artifact with `updated_at` set from disk.
+        """
+        full = self._resolve(artifact.path)
+        full.parent.mkdir(parents=True, exist_ok=True)
+        full.write_text(artifact.content)
+        st = full.stat()
+        stored = artifact.model_copy(update={"updated_at": datetime.fromtimestamp(st.st_mtime)})
+        self[artifact.path] = stored
+        if self.debug:
+            logger.debug("[LocalArtifactStore] wrote: {}", stored)
+        return stored

--- a/akd_ext/artifacts/stores/local.py
+++ b/akd_ext/artifacts/stores/local.py
@@ -8,13 +8,51 @@ from akd_ext.artifacts._base import Artifact, ArtifactStore
 
 
 class LocalArtifactStore(ArtifactStore[str]):
-    """Local file-system based artifact store."""
+    """Local file-system based artifact store.
+
+    Treats `self.root` as a directory on disk. `load_artifacts()` eagerly
+    walks the tree, filtering by `self.supported_extensions` and reading
+    each matched file as UTF-8 text into the cache.
+
+    Caching strategy: reads are freshness-checked against disk — the
+    cached copy is served only if its `updated_at` matches the file's
+    current mtime; otherwise the file is re-read and the cache is
+    refreshed. This keeps the store in sync with external edits without
+    requiring an explicit refresh.
+
+    Writes flush to disk (creating parent directories as needed) and
+    update the cache with the post-write mtime.
+
+    Path traversal is rejected at both the model level (via
+    `Artifact.path` validation) and the store level (via `_resolve`,
+    which rejects any path that escapes `self.root` via `..` or
+    symlinks).
+    """
+
+    def _resolve(self, rel_path: str) -> Path:
+        """Resolve a relative path to an absolute path under root.
+
+        Args:
+            rel_path: Path relative to `self.root`.
+
+        Returns:
+            Absolute filesystem path.
+
+        Raises:
+            ValueError: If the resolved path escapes `self.root`.
+        """
+        root_abs = Path(self.root).resolve()
+        full = (Path(self.root) / rel_path).resolve()
+        if not full.is_relative_to(root_abs):
+            raise ValueError(f"path escapes store root: {rel_path!r}")
+        return full
 
     async def load_artifacts(self) -> Self:
-        """Populate the cache by walking `self.root` and reading every file
-        whose extension is in `self.supported_extensions`. Each artifact's
-        path is its slug relative to root; `updated_at` is taken from the
-        filesystem mtime. Returns `self` for fluent chaining."""
+        """Load all available artifacts into the cache.
+
+        Returns:
+            Self, for fluent chaining.
+        """
         root = Path(self.root)
         if not root.exists():
             logger.warning(
@@ -35,3 +73,34 @@ class LocalArtifactStore(ArtifactStore[str]):
                 updated_at=datetime.fromtimestamp(st.st_mtime),
             )
         return self
+
+    async def read_artifact(self, path: str) -> Artifact[str]:
+        """Load the content of an artifact.
+
+        Args:
+            path: Path of the artifact to load (e.g. "contexts/role.md").
+
+        Returns:
+            The artifact including its content.
+
+        Raises:
+            FileNotFoundError: If no artifact exists at that path.
+        """
+        full = self._resolve(path)
+        if not full.is_file():
+            if path in self:
+                del self[path]
+            raise FileNotFoundError(f"artifact not found: {path!r}")
+
+        disk_mtime = datetime.fromtimestamp(full.stat().st_mtime)
+        cached = self._artifacts.get(path)
+        if cached is not None and cached.updated_at == disk_mtime:
+            return cached
+
+        artifact = Artifact[str](
+            path=path,
+            content=full.read_text(),
+            updated_at=disk_mtime,
+        )
+        self[path] = artifact
+        return artifact

--- a/akd_ext/artifacts/stores/local.py
+++ b/akd_ext/artifacts/stores/local.py
@@ -75,7 +75,7 @@ class LocalArtifactStore(ArtifactStore[str]):
         return self
 
     async def read_artifact(self, path: str) -> Artifact[str]:
-        """Load the content of an artifact.
+        """Fetch an artifact by path.
 
         Args:
             path: Path of the artifact to load (e.g. "contexts/role.md").

--- a/akd_ext/artifacts/stores/local.py
+++ b/akd_ext/artifacts/stores/local.py
@@ -1,0 +1,37 @@
+from datetime import datetime
+from pathlib import Path
+from typing import Self
+
+from loguru import logger
+
+from akd_ext.artifacts._base import Artifact, ArtifactStore
+
+
+class LocalArtifactStore(ArtifactStore[str]):
+    """Local file-system based artifact store."""
+
+    async def load_artifacts(self) -> Self:
+        """Populate the cache by walking `self.root` and reading every file
+        whose extension is in `self.supported_extensions`. Each artifact's
+        path is its slug relative to root; `updated_at` is taken from the
+        filesystem mtime. Returns `self` for fluent chaining."""
+        root = Path(self.root)
+        if not root.exists():
+            logger.warning(
+                "[LocalArtifactStore] root does not exist: {} — nothing to load",
+                root,
+            )
+            return self
+        for f in sorted(root.rglob("*")):
+            if not f.is_file():
+                continue
+            rel = str(f.relative_to(root))
+            if not self._is_supported(rel):
+                continue
+            st = f.stat()
+            self[rel] = Artifact[str](
+                path=rel,
+                content=f.read_text(),
+                updated_at=datetime.fromtimestamp(st.st_mtime),
+            )
+        return self

--- a/akd_ext/artifacts/utils.py
+++ b/akd_ext/artifacts/utils.py
@@ -1,0 +1,16 @@
+"""Small, pure helpers shared by Artifact, ArtifactStore, and concrete backends."""
+
+
+def canonical_ext(t: str) -> str:
+    """Normalize a user-supplied file-type hint to canonical `.ext` form.
+
+    Accepts any of:
+      - 'md'    -> '.md'
+      - '.md'   -> '.md'
+      - '*.md'  -> '.md'
+    """
+    if t.startswith("*."):
+        t = t[1:]
+    if not t.startswith("."):
+        t = f".{t}"
+    return t

--- a/tests/artifacts/conftest.py
+++ b/tests/artifacts/conftest.py
@@ -1,0 +1,27 @@
+"""Shared fixtures for artifact tests."""
+
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def artifact_tree(tmp_path: Path) -> Path:
+    """Build a small artifact tree on disk and return its root.
+
+    Layout:
+        artifacts/
+        ├── index.md
+        ├── contexts/
+        │   ├── index.md
+        │   └── role.md
+        └── data.json     # non-md, should be filtered out of the store
+    """
+    root = tmp_path / "artifacts"
+    root.mkdir()
+    (root / "index.md").write_text("# Root")
+    (root / "contexts").mkdir()
+    (root / "contexts" / "index.md").write_text("# Contexts")
+    (root / "contexts" / "role.md").write_text("# Role")
+    (root / "data.json").write_text("{}")
+    return root

--- a/tests/artifacts/test_local.py
+++ b/tests/artifacts/test_local.py
@@ -1,0 +1,33 @@
+"""Barebone tests for LocalArtifactStore: load, read, write."""
+
+from pathlib import Path
+
+from akd_ext.artifacts import Artifact
+from akd_ext.artifacts.stores.local import LocalArtifactStore
+
+
+async def test_load(artifact_tree: Path):
+    store = await LocalArtifactStore(root=str(artifact_tree)).load_artifacts()
+    assert len(store) == 3
+    assert "index.md" in store
+    assert "contexts/index.md" in store
+    assert "contexts/role.md" in store
+    # non-markdown file is filtered out by default supported_extensions
+    assert "data.json" not in store
+
+
+async def test_read(artifact_tree: Path):
+    store = await LocalArtifactStore(root=str(artifact_tree)).load_artifacts()
+    artifact = await store.read_artifact("contexts/role.md")
+    assert artifact.path == "contexts/role.md"
+    assert artifact.content.strip() == "# Role"
+
+
+async def test_write(artifact_tree: Path):
+    store = await LocalArtifactStore(root=str(artifact_tree)).load_artifacts()
+    stored = await store.write_artifact(Artifact(path="notes/todo.md", content="# Todo"))
+    assert stored.path == "notes/todo.md"
+    # file exists on disk
+    assert (artifact_tree / "notes" / "todo.md").read_text() == "# Todo"
+    # cache updated
+    assert "notes/todo.md" in store


### PR DESCRIPTION
Follow-up to #75 — lands the first concrete `ArtifactStore` backend (filesystem) and generalizes the ABC to filter by file extension.

## Major Changes

- **`LocalArtifactStore(ArtifactStore[str])`** — filesystem-backed artifact store. Implements the three abstracts:
  - **`load_artifacts()`** — eagerly walks `self.root`, filters via `_is_supported()`, reads each matched file as UTF-8 text, stamps `updated_at` from filesystem mtime.
  - **`read_artifact(path)`** — **mtime-checked cache**: compares cached `updated_at` to current `st_mtime`; serves from cache on match, re-reads from disk otherwise. Keeps the store in sync with external edits without requiring explicit refresh.
  - **`write_artifact(artifact)`** — persists content to disk (creating parent dirs as needed), updates cache with fresh mtime, returns the stored artifact.
  - **`_resolve(path)`** — path-traversal guard via `Path.resolve() + is_relative_to(root)`. Layer 2 defense on top of the model-level `Artifact.path` validator (rejects `..` / symlink escapes).

- **`supported_extensions` kwarg on the `ArtifactStore` ABC** — tuple of file extensions to filter on load. Default `(".md",)`. Accepts `"md"` / `".md"` / `"*.md"` — all canonicalize to `".md"`. Empty tuple `()` disables filtering. Non-markdown assets (large JSONs, lookup tables like ada's `gcmd.json`) stay out of the store by default and are read directly from `store.root / ...` by tool code.

## Minor Changes

- **`akd_ext.artifacts.utils`** — new module for shared helpers. Adds `canonical_ext(t: str) -> str` used by the extension normalizer.
- **`_is_supported(path)` helper** on the ABC — called by concrete stores in `load_artifacts` to filter by extension.
- **Per-store `debug` flag** — when `True`, `write_artifact` emits a `logger.debug` line on successful write (useful for CARE iteration tracing).
- **Warning on missing root** — `load_artifacts` logs a warning instead of erroring if `self.root` doesn't exist yet (so a store can be constructed before any writes).

## Testing

All tests pass locally:

```
$ uv run pytest tests/artifacts -v
...
========================== 6 passed in 1.68s ===========================
```

6 tests total — 3 ABC smoke tests from #75 + 3 new `LocalArtifactStore` tests (`test_load`, `test_read`, `test_write`) using a shared `artifact_tree` fixture over pytest's `tmp_path`.

Tree exercised in tests (the `artifact_tree` fixture):

```
artifacts/
├── index.md
├── contexts/
│   ├── index.md
│   └── role.md
└── data.json    # non-md, filtered out by default supported_extensions
```

## Next Steps (follow-up PRs)

- **Agent-compatible tool wrappers** in the pydantic-ai base agent. The store's `read_artifact` returns a full `Artifact` object; for LLM tool use, expose a thin wrapper that returns only `content: str` — fewer tokens, simpler JSON schema for the model. Same pattern for `write_artifact` — wrap to `(path, content)` scalars. Lands alongside the pydantic-ai integration once #74 merges.
- **`ArtifactError` hierarchy** in `akd_ext/artifacts/errors.py` — `ArtifactNotFoundError` / `ArtifactPathEscapeError` inheriting from `akd.errors.AKDError`, replacing the current generic `FileNotFoundError` / `ValueError` raises.
- **`ReadOnlyArtifactStore`** wrapper — for the CARE-published portion of a deployed agent's store.
- **`LayeredArtifactStore`** composite — merges a read-only base (published CARE artifacts) with a writable overlay (session-level iterative artifacts) into one unified view for the agent.
- **`GitHubArtifactStore`** — reuses existing `PyGithub` dep; same slug-based API so the agent can't tell the difference between local and GitHub.