### PR TITLE
add ToolCallLimits capability on PydanticAIBaseAgent via scalar wiring

### DIFF
--- a/akd_ext/agents/_base/pydantic_ai/_base.py
+++ b/akd_ext/agents/_base/pydantic_ai/_base.py
@@ -50,6 +50,7 @@ from akd._base.protocols import AKDExecutable, RunContextProtocol
 from akd._base.structures import RunContext as AKDRunContext
 from akd.agents._base import BaseAgentConfig
 
+from ._capabilities import ToolCallLimits
 from ._event_translator import pai_event_to_akd_event
 from ._tool_adapter import akd_to_pai_tool
 
@@ -328,15 +329,30 @@ class PydanticAIBaseAgent[InSchema: InputSchema, OutSchema: OutputSchema](
     # ── Zone 1: scalar-driven capability construction ────────────────────
 
     def _build_capabilities_from_scalars(self) -> list[AbstractCapability]:
-        """Derive capabilities from (scalar) AKD config fields.
+        """Derive pydantic_ai capabilities from scalar AKD config fields.
+
+        Current wiring:
+
+        - ``max_tool_iterations`` / ``max_tool_calls`` → ``ToolCallLimits``
+          — caps the model-request loop and total tool executions per agent
+          instance; raises ``MaxToolIterationsExceeded`` /
+          ``MaxToolCallsExceeded`` (subclasses of ``UsageLimitExceeded``)
+          which pydantic_ai surfaces via ``UnexpectedModelBehavior`` to the
+          caller.
 
         Subclasses override to append their own scalar→capability mappings;
-        call ``super()._build_capabilities_from_scalars()`` first to inherit
-        future defaults.
-
-        TLDR; this is to map configs to a capability in pydanticAI
+        call ``super()._build_capabilities_from_scalars()`` first to
+        inherit the defaults.
         """
-        return []
+        caps: list[AbstractCapability] = []
+        if self.config.max_tool_iterations or self.config.max_tool_calls:
+            caps.append(
+                ToolCallLimits(
+                    max_iterations=self.config.max_tool_iterations,
+                    max_calls=self.config.max_tool_calls,
+                ),
+            )
+        return caps
 
     # ── Tool adaptation ──────────────────────────────────────────────────
 

--- a/akd_ext/agents/_base/pydantic_ai/_capabilities.py
+++ b/akd_ext/agents/_base/pydantic_ai/_capabilities.py
@@ -1,0 +1,65 @@
+"""Custom pydantic_ai Capabilities built from AKD scalar config fields.
+
+Concrete implementations behind ``PydanticAIBaseAgent``'s
+``_build_capabilities_from_scalars`` hook. Each factory here returns a
+ready-to-use pydantic_ai ``Hooks`` capability; the base agent constructs
+them at ``__init__`` time from the relevant ``BaseAgentConfig`` fields.
+"""
+
+from __future__ import annotations
+
+from pydantic_ai.capabilities.hooks import Hooks
+
+from akd._base.errors import MaxToolCallsExceeded, MaxToolIterationsExceeded
+
+
+def ToolCallLimits(
+    *,
+    max_iterations: int | None = None,
+    max_calls: int | None = None,
+) -> Hooks:
+    """Build a ``Hooks`` capability that caps tool-loop iterations and total tool calls.
+
+    Counters live in closure state; each agent instance gets its own
+    ``Hooks`` via ``_build_capabilities_from_scalars``. Counters reset on
+    agent construction, not per-run — which mirrors AKD's historical ReAct
+    cap semantics. Callers who need per-run reset should reconstruct the
+    agent.
+
+    Raises:
+        MaxToolIterationsExceeded: when ``max_iterations`` is set and the
+            model-request loop would exceed the cap on the next round.
+        MaxToolCallsExceeded: when ``max_calls`` is set and the total number
+            of tool executions would exceed the cap.
+    """
+    hooks = Hooks()
+    state = {"iterations": 0, "calls": 0}
+
+    if max_iterations is not None:
+
+        @hooks.on.before_model_request
+        async def _cap_iterations(ctx, request_context):  # noqa: ARG001
+            state["iterations"] += 1
+            if state["iterations"] > max_iterations:
+                raise MaxToolIterationsExceeded(
+                    f"Exceeded max tool iterations ({max_iterations}).",
+                )
+            return request_context
+
+    if max_calls is not None:
+
+        @hooks.on.before_tool_execute
+        async def _cap_calls(ctx, *, call, tool_def, args):  # noqa: ARG001
+            state["calls"] += 1
+            if state["calls"] > max_calls:
+                raise MaxToolCallsExceeded(
+                    f"Exceeded max tool calls ({max_calls}).",
+                )
+            return args
+
+    return hooks
+
+
+__all__ = [
+    "ToolCallLimits",
+]

--- a/tests/agents/test_base_pydantic.py
+++ b/tests/agents/test_base_pydantic.py
@@ -50,6 +50,8 @@ class _EchoOutput(OutputSchema):
 class _EchoConfig(PydanticAIBaseAgentConfig):
     """Config for the echo test agent."""
 
+    enable_extra_capability: bool = Field(default=False)
+
 
 class _EchoAgent(PydanticAIBaseAgent[_EchoInput, _EchoOutput]):
     """Minimal test agent exercising the base class's feature surface."""
@@ -438,3 +440,77 @@ async def test_existing_akd_tool_is_pai_compatible():
     assert isinstance(akd_tool, AKDTool)
     # And the input schema reference is intact.
     assert akd_tool.input_schema is DummyInputSchema
+
+
+# ---------------------------------------------------------------------------
+# Phase 3a: ToolCallLimits capability + _build_capabilities_from_scalars wiring
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_tool_call_limits_raises_max_iterations():
+    """The ``before_model_request`` hook raises ``MaxToolIterationsExceeded``
+    on the first invocation that pushes the counter past ``max_iterations``."""
+    from akd._base.errors import MaxToolIterationsExceeded
+
+    from akd_ext.agents._base.pydantic_ai._capabilities import ToolCallLimits
+
+    hooks = ToolCallLimits(max_iterations=1)
+
+    # First invocation: counter goes from 0 → 1; 1 > 1 is False; pass.
+    result = await hooks.before_model_request(None, "request-context-sentinel")
+    assert result == "request-context-sentinel"
+
+    # Second invocation: counter 1 → 2; 2 > 1 triggers the cap.
+    with pytest.raises(MaxToolIterationsExceeded, match="max tool iterations"):
+        await hooks.before_model_request(None, "request-context-sentinel")
+
+
+@pytest.mark.asyncio
+async def test_tool_call_limits_raises_max_calls():
+    """The ``before_tool_execute`` hook raises ``MaxToolCallsExceeded`` on the
+    first invocation that pushes the counter past ``max_calls``."""
+    from akd._base.errors import MaxToolCallsExceeded
+
+    from akd_ext.agents._base.pydantic_ai._capabilities import ToolCallLimits
+
+    hooks = ToolCallLimits(max_calls=1)
+
+    result = await hooks.before_tool_execute(None, call=None, tool_def=None, args="args-sentinel")
+    assert result == "args-sentinel"
+
+    with pytest.raises(MaxToolCallsExceeded, match="max tool calls"):
+        await hooks.before_tool_execute(None, call=None, tool_def=None, args="args-sentinel")
+
+
+def test_build_capabilities_from_scalars_includes_tool_call_limits():
+    """When ``max_tool_iterations`` / ``max_tool_calls`` are set on the config,
+    ``_build_capabilities_from_scalars`` must include a ``Hooks`` capability
+    (the one produced by ``ToolCallLimits``)."""
+    from pydantic_ai.capabilities.hooks import Hooks
+
+    agent = _EchoAgent(_EchoConfig(max_tool_iterations=3))
+    caps = agent._build_capabilities_from_scalars()
+    assert any(isinstance(c, Hooks) for c in caps), f"expected a Hooks capability in {caps!r}"
+
+
+def test_subclass_can_extend_capabilities_hook():
+    """Subclasses may override ``_build_capabilities_from_scalars`` and call super()."""
+
+    class _MarkerCapability:
+        """Stand-in capability used to assert the hook was invoked."""
+
+    class _ExtAgent(_EchoAgent):
+        """Echo agent that adds a marker capability when enabled."""
+
+        def _build_capabilities_from_scalars(self):
+            caps = super()._build_capabilities_from_scalars()
+            if self.config.enable_extra_capability:
+                caps.append(_MarkerCapability())
+            return caps
+
+    # Bypass __init__; we only want the method output.
+    agent = _ExtAgent.__new__(_ExtAgent)
+    agent.config = _EchoConfig(enable_extra_capability=True)
+    produced = agent._build_capabilities_from_scalars()
+    assert any(isinstance(c, _MarkerCapability) for c in produced)


### PR DESCRIPTION
 ## Summary
  Fills in `PydanticAIBaseAgent._build_capabilities_from_scalars()` —  Consumers who set `max_tool_iterations` or `max_tool_calls` on the config now get a hard runtime cap enforced during the model-request loop and tool-execution
   path, with AKD's existing `UsageLimitExceeded` family of errors surfacing cleanly through pydantic_ai's `UnexpectedModelBehavior`.

  ## What it does
  - Agents built on `PydanticAIBaseAgent` respect `max_tool_iterations` and `max_tool_calls` from the inherited `BaseAgentConfig` — the ReAct loop no longer runs unbounded.
  - When a cap is hit, the run raises `MaxToolIterationsExceeded` / `MaxToolCallsExceeded` (both subclasses of `UsageLimitExceeded`), mirroring the semantics the legacy OpenAI-based`BaseAgent` already exposes.
  - Subclasses can still extend the capability list by overriding `_build_capabilities_from_scalars`, calling `super()`, and appending (the extension pattern is now pinned by a test).
  - No new config fields on `PydanticAIBaseAgentConfig` — both scalars come in from `BaseAgentConfig` unchanged.

  ## Files changed
  - **New files:**
    - `akd_ext/agents/_base/pydantic_ai/_capabilities.py` — holds `ToolCallLimits` (Hooks factory, closure state, two conditional lifecycle callbacks). 
  -  **Modified files:**
    - `akd_ext/agents/_base/pydantic_ai/_base.py` — imports `ToolCallLimits`; `_build_capabilities_from_scalars` body replaced with the `max_tool_iterations` / `max_tool_calls`.
    - `tests/agents/test_base_pydantic.py` — adds four tests under ToolCallLimits" section; restores one field on `_EchoConfig` (`enable_extra_capability: bool`) that the subclass-extension test needs.

  ## Testing
  Run the test suite (hermetic; no network, no model keys):

      uv run pytest tests/agents/test_base_pydantic.py -n=3
