### PR TITLE
feat(agents): add ReflectionCapability + scalar wiring

### DIFF
--- a/akd_ext/agents/_base/pydantic_ai/_base.py
+++ b/akd_ext/agents/_base/pydantic_ai/_base.py
@@ -50,6 +50,7 @@ from akd._base.protocols import AKDExecutable, RunContextProtocol
 from akd._base.structures import RunContext as AKDRunContext
 from akd.agents._base import BaseAgentConfig
 
+from ._capabilities import ReflectionCapability
 from ._event_translator import pai_event_to_akd_event
 from ._tool_adapter import akd_to_pai_tool
 
@@ -328,15 +329,23 @@ class PydanticAIBaseAgent[InSchema: InputSchema, OutSchema: OutputSchema](
     # ── Zone 1: scalar-driven capability construction ────────────────────
 
     def _build_capabilities_from_scalars(self) -> list[AbstractCapability]:
-        """Derive capabilities from (scalar) AKD config fields.
+        """Derive pydantic_ai capabilities from scalar AKD config fields.
+
+        Current wiring:
+
+        - ``reflection_prompt`` → ``ReflectionCapability`` — injects the
+          prompt as a system-level nudge on every model request after the
+          first, forcing the agent to reflect before returning a final
+          answer.
 
         Subclasses override to append their own scalar→capability mappings;
-        call ``super()._build_capabilities_from_scalars()`` first to inherit
-        future defaults.
-
-        TLDR; this is to map configs to a capability in pydanticAI
+        call ``super()._build_capabilities_from_scalars()`` first to
+        inherit the defaults.
         """
-        return []
+        caps: list[AbstractCapability] = []
+        if self.config.reflection_prompt:
+            caps.append(ReflectionCapability(prompt=self.config.reflection_prompt))
+        return caps
 
     # ── Tool adaptation ──────────────────────────────────────────────────
 

--- a/akd_ext/agents/_base/pydantic_ai/_capabilities.py
+++ b/akd_ext/agents/_base/pydantic_ai/_capabilities.py
@@ -1,0 +1,45 @@
+"""Custom pydantic_ai Capabilities built from AKD scalar config fields.
+
+Concrete implementations behind ``PydanticAIBaseAgent``'s
+``_build_capabilities_from_scalars`` hook. Each factory here returns a
+ready-to-use pydantic_ai ``Hooks`` capability; the base agent constructs
+them at ``__init__`` time from the relevant ``BaseAgentConfig`` fields.
+"""
+
+from __future__ import annotations
+
+from pydantic_ai.capabilities.hooks import Hooks
+
+
+def ReflectionCapability(*, prompt: str) -> Hooks:
+    """Build a ``Hooks`` capability that injects ``prompt`` before each model
+    request after the first.
+
+    Implementation: a counter tracks how many model requests have fired;
+    from the second onwards, we prepend the reflection prompt as a system
+    instruction to the pending request. The first request is skipped so
+    the reflection prompt never leaks into the initial user-facing turn.
+    """
+    from pydantic_ai.messages import ModelRequest, SystemPromptPart
+
+    hooks = Hooks()
+    state = {"turn": 0}
+
+    @hooks.on.before_model_request
+    async def _inject_reflection(ctx, request_context):  # noqa: ARG001
+        state["turn"] += 1
+        if state["turn"] == 1:
+            return request_context
+        # Prepend the reflection as a system message on this turn
+        request_context.messages = [
+            ModelRequest(parts=[SystemPromptPart(content=prompt)]),
+            *request_context.messages,
+        ]
+        return request_context
+
+    return hooks
+
+
+__all__ = [
+    "ReflectionCapability",
+]

--- a/tests/agents/test_base_pydantic.py
+++ b/tests/agents/test_base_pydantic.py
@@ -50,6 +50,8 @@ class _EchoOutput(OutputSchema):
 class _EchoConfig(PydanticAIBaseAgentConfig):
     """Config for the echo test agent."""
 
+    enable_extra_capability: bool = Field(default=False)
+
 
 class _EchoAgent(PydanticAIBaseAgent[_EchoInput, _EchoOutput]):
     """Minimal test agent exercising the base class's feature surface."""
@@ -438,3 +440,90 @@ async def test_existing_akd_tool_is_pai_compatible():
     assert isinstance(akd_tool, AKDTool)
     # And the input schema reference is intact.
     assert akd_tool.input_schema is DummyInputSchema
+
+
+# ---------------------------------------------------------------------------
+# Phase 3b: ReflectionCapability + _build_capabilities_from_scalars wiring
+# ---------------------------------------------------------------------------
+
+
+class _FakeRequestContext:
+    """Tiny stand-in for pydantic_ai's ModelRequestContext.
+
+    The reflection hook only reads and mutates ``.messages`` on the
+    request context; any object with that attribute is enough for a
+    direct-invocation unit test.
+    """
+
+    def __init__(self, messages):
+        self.messages = messages
+
+
+@pytest.mark.asyncio
+async def test_reflection_capability_skips_first_turn():
+    """The first model request must pass through untouched so the
+    reflection prompt never leaks into the initial user-facing turn."""
+    from akd_ext.agents._base.pydantic_ai._capabilities import ReflectionCapability
+
+    hooks = ReflectionCapability(prompt="reflect please")
+
+    ctx = _FakeRequestContext(messages=[])
+    result = await hooks.before_model_request(None, ctx)
+    assert result is ctx
+    assert ctx.messages == []  # nothing injected
+
+
+@pytest.mark.asyncio
+async def test_reflection_capability_injects_on_subsequent_turns():
+    """On turn 2 onwards the reflection prompt is prepended as a
+    ``SystemPromptPart`` on a fresh ``ModelRequest``."""
+    from pydantic_ai.messages import ModelRequest, SystemPromptPart
+
+    from akd_ext.agents._base.pydantic_ai._capabilities import ReflectionCapability
+
+    hooks = ReflectionCapability(prompt="reflect please")
+
+    ctx = _FakeRequestContext(messages=[])
+    await hooks.before_model_request(None, ctx)  # turn 1: skipped
+    await hooks.before_model_request(None, ctx)  # turn 2: inject
+
+    assert len(ctx.messages) == 1
+    injected = ctx.messages[0]
+    assert isinstance(injected, ModelRequest)
+    assert len(injected.parts) == 1
+    part = injected.parts[0]
+    assert isinstance(part, SystemPromptPart)
+    assert part.content == "reflect please"
+
+
+def test_build_capabilities_from_scalars_includes_reflection_capability():
+    """``_build_capabilities_from_scalars`` must include a ``Hooks`` capability
+    (the one produced by ``ReflectionCapability``) when ``reflection_prompt``
+    is set on the config."""
+    from pydantic_ai.capabilities.hooks import Hooks
+
+    agent = _EchoAgent(_EchoConfig(reflection_prompt="do reflect"))
+    caps = agent._build_capabilities_from_scalars()
+    assert any(isinstance(c, Hooks) for c in caps), f"expected a Hooks capability in {caps!r}"
+
+
+def test_subclass_can_extend_capabilities_hook():
+    """Subclasses may override ``_build_capabilities_from_scalars`` and call super()."""
+
+    class _MarkerCapability:
+        """Stand-in capability used to assert the hook was invoked."""
+
+    class _ExtAgent(_EchoAgent):
+        """Echo agent that adds a marker capability when enabled."""
+
+        def _build_capabilities_from_scalars(self):
+            caps = super()._build_capabilities_from_scalars()
+            if self.config.enable_extra_capability:
+                caps.append(_MarkerCapability())
+            return caps
+
+    # Bypass __init__; we only want the method output.
+    agent = _ExtAgent.__new__(_ExtAgent)
+    agent.config = _EchoConfig(enable_extra_capability=True)
+    produced = agent._build_capabilities_from_scalars()
+    assert any(isinstance(c, _MarkerCapability) for c in produced)


### PR DESCRIPTION
## Summary
  Adds the next scalar-to-capability mapping on `PydanticAIBaseAgent`: `reflection_prompt → ReflectionCapability`. When the config carries a reflection prompt, the agent will inject it as a system-level nudge before every model request after the first — a hook that forces the model to step back and reason about tool results before returning a final answer, mirroring the
  legacy AKD agent's reflection pass.

  ## What it does
  - Agents built on `PydanticAIBaseAgent` now respect `config.reflection_prompt` — set it to a string and the agent automatically injects that string as a `SystemPromptPart` on every model  request after the first.
  - The initial user-facing turn is preserved untouched; reflection kicks in only once there's something to reflect *on* (turn 2+).
  - Subclasses can still extend `_build_capabilities_from_scalars` via `super()` + append — the extension pattern is pinned by a test.
  - No new config fields on `PydanticAIBaseAgentConfig`; `reflection_prompt` comes in from `BaseAgentConfig` unchanged.

  ## Files changed
  - **New files:**
    - `akd_ext/agents/_base/pydantic_ai/_capabilities.py` — holds `ReflectionCapability` (Hooks factory with closured turn counter). Module docstring notes future factories land here.
  - **Modified files:**
    - `akd_ext/agents/_base/pydantic_ai/_base.py` — imports `ReflectionCapability`; `_build_capabilities_from_scalars` body replaced with the `reflection_prompt`.
    - `tests/agents/test_base_pydantic.py` — adds four tests under a new "Phase 3b: ReflectionCapability" section; adds `enable_extra_capability: bool` on `_EchoConfig` for the
  subclass-extension test.

  ## Testing
  Hermetic test suite (no network, no model keys):

      uv run pytest tests/agents/test_base_pydantic.py -n=3