### PR TITLE
add thinking capability on PydanticAIBaseAgent via scalar wiring

### DIFF
--- a/akd_ext/agents/_base/pydantic_ai/_base.py
+++ b/akd_ext/agents/_base/pydantic_ai/_base.py
@@ -328,15 +328,24 @@ class PydanticAIBaseAgent[InSchema: InputSchema, OutSchema: OutputSchema](
     # ── Zone 1: scalar-driven capability construction ────────────────────
 
     def _build_capabilities_from_scalars(self) -> list[AbstractCapability]:
-        """Derive capabilities from (scalar) AKD config fields.
+        """Derive pydantic_ai capabilities from scalar AKD config fields.
+
+        Current wiring:
+
+        - ``reasoning_effort`` → ``pydantic_ai.capabilities.Thinking`` —
+          turns on the model's reasoning / extended-thinking mode at the
+          requested effort level. No-op on non-reasoning models.
 
         Subclasses override to append their own scalar→capability mappings;
-        call ``super()._build_capabilities_from_scalars()`` first to inherit
-        future defaults.
-
-        TLDR; this is to map configs to a capability in pydanticAI
+        call ``super()._build_capabilities_from_scalars()`` first to
+        inherit the defaults.
         """
-        return []
+        from pydantic_ai.capabilities import Thinking
+
+        caps: list[AbstractCapability] = []
+        if self.config.reasoning_effort:
+            caps.append(Thinking(effort=self.config.reasoning_effort))
+        return caps
 
     # ── Tool adaptation ──────────────────────────────────────────────────
 

--- a/tests/agents/test_base_pydantic.py
+++ b/tests/agents/test_base_pydantic.py
@@ -438,3 +438,33 @@ async def test_existing_akd_tool_is_pai_compatible():
     assert isinstance(akd_tool, AKDTool)
     # And the input schema reference is intact.
     assert akd_tool.input_schema is DummyInputSchema
+
+
+# ---------------------------------------------------------------------------
+# reasoning_effort → Thinking capability wiring
+# ---------------------------------------------------------------------------
+
+
+def test_build_capabilities_from_scalars_includes_thinking():
+    """When ``reasoning_effort`` is set on the config,
+    ``_build_capabilities_from_scalars`` must include a ``Thinking``
+    capability carrying the requested effort level."""
+    from pydantic_ai.capabilities import Thinking
+
+    agent = _EchoAgent(_EchoConfig(reasoning_effort="high"))
+    caps = agent._build_capabilities_from_scalars()
+    thinking_caps = [c for c in caps if isinstance(c, Thinking)]
+    assert thinking_caps, f"expected a Thinking capability in {caps!r}"
+    assert thinking_caps[0].effort == "high"
+
+
+def test_build_capabilities_from_scalars_skips_thinking_when_unset():
+    """Default config has ``reasoning_effort=None``; no ``Thinking``
+    capability should be emitted (the field is an opt-in)."""
+    from pydantic_ai.capabilities import Thinking
+
+    agent = _EchoAgent(_EchoConfig())
+    caps = agent._build_capabilities_from_scalars()
+    assert not any(isinstance(c, Thinking) for c in caps), (
+        f"Thinking should not be wired when reasoning_effort is None; got {caps!r}"
+    )


### PR DESCRIPTION
 ## Summary
  Adds the last remaining scalar-to-capability mapping on `PydanticAIBaseAgent`: `reasoning_effort → pydantic_ai.capabilities.Thinking`. Until this PR, consumers who set
  `config.reasoning_effort = "high"` on an AKD config got no behavior change — the field sat unused by the pydantic_ai runtime. Now that scalar actually enables the model's reasoning /
  extended-thinking mode when the underlying model supports it.

  ## What it does
  - Setting `reasoning_effort` to `"low"` / `"medium"` / `"high"` on a `PydanticAIBaseAgentConfig` now turns on the underlying model's reasoning mode at the requested effort level.
  - No-op on models that don't support reasoning — pydantic_ai ignores the `Thinking` capability for those models, so plain `gpt-4o` / `gpt-4o-mini` runs keep working unchanged.
  - No new config field to learn — `reasoning_effort` was already on `BaseAgentConfig` and documented; this PR just makes it effective.
  - Subclasses that override `_build_capabilities_from_scalars()` and call `super()` pick up the Thinking branch automatically.

  ## Files changed
  - **Modified files:**
    - `akd_ext/agents/_base/pydantic_ai/_base.py` — `_build_capabilities_from_scalars()` body replaced with the reasoning_effort branch; docstring lists current + future wirings; inline
  `from pydantic_ai.capabilities import Thinking` import at the top of the method.
    - `tests/agents/test_base_pydantic.py` — adds two tests under a new "reasoning_effort → Thinking" section.

  ## Testing
  Hermetic test suite (no network, no model keys):

      uv run pytest tests/agents/test_base_pydantic.py -n=3