### PR TITLE
fix: update cmr_care prompt

### DIFF
--- a/akd_ext/agents/cmr_care.py
+++ b/akd_ext/agents/cmr_care.py
@@ -126,6 +126,11 @@ CMR_DATA_SEARCH_CARE_AGENT_SYSTEM_PROMPT = """ROLE
 
     16. Progress over paralysis — proceed with transparent defaults rather than blocking on clarification.
 
+    17. When asking clarification questions, always number them (1., 2., 3., ...) so the user can respond to each individually.
+
+    18. Clarification-turn output rule: When the response is clarifying questions only (no CMR search run yet), output ONLY the numbered questions followed by the "skip" fast-path line. 
+    Do NOT render "Interpreted Scope", "Curated / Ranked CMR Dataset List", or any other OUTPUT FORMAT section in this turn. The full OUTPUT FORMAT applies only when actual search results are being returned.
+
     OUTPUT FORMAT
     All responses must follow this structure exactly. No free-form text is allowed outside these sections.
     1. Interpreted Scope

--- a/akd_ext/agents/cmr_care.py
+++ b/akd_ext/agents/cmr_care.py
@@ -126,7 +126,7 @@ CMR_DATA_SEARCH_CARE_AGENT_SYSTEM_PROMPT = """ROLE
 
     16. Progress over paralysis — proceed with transparent defaults rather than blocking on clarification.
 
-    17. When asking clarification questions, always number them (1., 2., 3., ...) so the user can respond to each individually.
+    17. When asking clarification questions, always number them (1., 2., 3., ...) so the user can respond to each individually and heading Clarifying Questions.
 
     18. Clarification-turn output rule: When the response is clarifying questions only (no CMR search run yet), output ONLY the numbered questions followed by the "skip" fast-path line. 
     Do NOT render "Interpreted Scope", "Curated / Ranked CMR Dataset List", or any other OUTPUT FORMAT section in this turn. The full OUTPUT FORMAT applies only when actual search results are being returned.


### PR DESCRIPTION
## Summary: 

- Updated CMR Care prompt for a cleaner clarifying question response

## Changes Made:

```
17. When asking clarification questions, always number them (1., 2., 3., ...) so the user can respond to each individually.

18. Clarification-turn output rule: When the response is clarifying questions only (no CMR search run yet), output ONLY the numbered questions followed by the "skip" fast-path line. 
    Do NOT render "Interpreted Scope", "Curated / Ranked CMR Dataset List", or any other OUTPUT FORMAT section in this turn. The full OUTPUT FORMAT applies only when actual search results are being returned.
```
