### PR TITLE
fix: udpate agent description astro agent

### DIFF
--- a/akd_ext/agents/astro_search_care.py
+++ b/akd_ext/agents/astro_search_care.py
@@ -388,7 +388,7 @@ class AstroSearchConfig(OpenAIBaseAgentConfig):
     description: str = Field(
         default="""Astrophysics dataset discovery agent for finding astronomical data across NASA archives
         (MAST, HEASARC, IRSA) via Astroquery and ADS. Supports object-based, coordinate-based,
-        literature-driven, and event-driven search patterns for researchers at all experience levels.
+        and event-driven search patterns for researchers at all experience levels.
         Outputs are delivered via a structured schema and interactive chat with the user for clarification,
         guidance, approval gates, or status updates."""
     )


### PR DESCRIPTION
## Summary:

- Removed the `literature review` keyword from the agent description, its been used by planner which then hallucinates in guiding user a possibility of literature review.