### PR TITLE
Auto-wire Thinking capability from reasoning_effort

### DIFF
--- a/akd_ext/agents/_base/pydantic_ai/_base.py
+++ b/akd_ext/agents/_base/pydantic_ai/_base.py
@@ -32,7 +32,7 @@ from typing import Any
 from pydantic import ConfigDict, Field, model_validator
 from pydantic_ai import Agent as PAIAgent
 from pydantic_ai import AgentRunResultEvent, ModelRetry
-from pydantic_ai.capabilities import AbstractCapability
+from pydantic_ai.capabilities import AbstractCapability, Thinking
 from pydantic_ai.capabilities.hooks import Hooks
 
 from akd._base import (
@@ -95,6 +95,17 @@ class PydanticAIBaseAgentConfig(BaseAgentConfig):
 
     @model_validator(mode="after")
     def validate_reasoning_params(self):
+        return self
+
+    @model_validator(mode="after")
+    def _wire_thinking_from_reasoning_effort(self):
+        """Auto-append a ``Thinking`` capability when ``reasoning_effort`` is set.
+
+        Skips if the user already supplied a ``Thinking`` capability —
+        their explicit value wins over the scalar default.
+        """
+        if self.reasoning_effort and not any(isinstance(c, Thinking) for c in self.capabilities):
+            self.capabilities.append(Thinking(effort=self.reasoning_effort))
         return self
 
 


### PR DESCRIPTION
# Major Changes

- Add a `@model_validator(mode="after")` on `PydanticAIBaseAgentConfig` that appends `pydantic_ai.capabilities.Thinking(effort=self.reasoning_effort)` to `capabilities` whenever `reasoning_effort` is set.
- Validator is dedup-aware: if the user already supplied a `Thinking` capability, it's left untouched (explicit user value wins over the scalar default).
- Promotes `Thinking` to a module-level import alongside the other `pydantic_ai.capabilities` symbols.

Result: callers who only want extended thinking can set `reasoning_effort="medium"` on the config and skip the manual `Thinking(...)` wiring.

## Usage

```python
from akd_ext.agents._base import PydanticAIBaseAgent, PydanticAIBaseAgentConfig

class MyAgent(PydanticAIBaseAgent[MyIn, MyOut]):
    input_schema = MyIn
    output_schema = MyOut

# scalar — Thinking is added automatically:
config = PydanticAIBaseAgentConfig(
    model_name="anthropic:claude-opus-4-7",
    reasoning_effort="medium",
)
# config.capabilities now contains Thinking(effort="medium")

# Explicit override still wins:
from pydantic_ai.capabilities import Thinking

config = PydanticAIBaseAgentConfig(
    model_name="anthropic:claude-opus-4-7",
    reasoning_effort="medium",
    capabilities=[Thinking(effort="low")],     # user's value
)
# only the user's Thinking(effort="low") is in capabilities — no duplicate

agent = MyAgent(config)
```

## Test plan

- [x] Existing 25 tests in `tests/agents/test_base_pydantic.py` still pass.
- [ ] Optional follow-up: dedicated tests for the validator (config with `reasoning_effort` → has Thinking; user-pre-supplied Thinking → not duplicated).