### PR TITLE
Call _bind_metadata and merge description into system_prompt

### DIFF
--- a/akd_ext/agents/_base/pydantic_ai/_base.py
+++ b/akd_ext/agents/_base/pydantic_ai/_base.py
@@ -174,6 +174,7 @@ class PydanticAIBaseAgent[InSchema: InputSchema, OutSchema: OutputSchema](
 
     def __init__(self, config: PydanticAIBaseAgentConfig | None = None) -> None:
         self.config = config or self.config_schema()
+        self._bind_metadata()
 
         # Forward-compat: any unknown fields the caller put on the config
         # (via ``extra="allow"``) pass straight through to pydantic_ai.
@@ -186,9 +187,14 @@ class PydanticAIBaseAgent[InSchema: InputSchema, OutSchema: OutputSchema](
         self._live_pai_ctx: Any = None
         ctx_capture = self._build_run_context_capture()
 
+        # merge description into prompt
+        prompts: tuple[str, ...] = (self.config.system_prompt,)
+        if self.config.description:
+            prompts += (f"AGENT DESCRIPTION:\n{self.config.description}",)
+
         super().__init__(
             model=self.config.model_name,
-            system_prompt=self.config.system_prompt,
+            system_prompt=prompts,
             name=self.config.name,
             description=self.config.description,
             retries=self.config.num_retries,

--- a/tests/agents/test_base_pydantic.py
+++ b/tests/agents/test_base_pydantic.py
@@ -84,7 +84,7 @@ def test_agent_instantiates_with_custom_config():
 
 def test_metaclass_auto_exposes_config_fields():
     """agent.model_name / agent.description route to self.config.* without hand-written properties."""
-    cfg = _EchoConfig(model_name="test", description="hello")
+    cfg = _EchoConfig(model_name="test", description="hello", io_hints=False)
     agent = _EchoAgent(cfg)
     assert agent.model_name == "test"
     assert agent.description == "hello"


### PR DESCRIPTION
- __init__ calls self._bind_metadata() to populate description from class docstring + I/O hints (matches akd-core convention).
- system_prompt is now a tuple (system_prompt, description) — pai keeps each as a separate SystemPromptPart.
- Updated metaclass test to use io_hints=False where it asserts on raw description.