### PR TITLE
fix: ToolResultEvent for non MCP call giving `unknown` tool name

### DIFF
--- a/akd_ext/agents/_base/openai.py
+++ b/akd_ext/agents/_base/openai.py
@@ -776,7 +776,14 @@ class OpenAIBaseAgent[InSchema: InputSchema, OutSchema: OutputSchema](
                                 data=ToolResultEventData(
                                     result=ToolResult(
                                         tool_call_id=tool_call_id,
-                                        tool_name=getattr(raw_item, "name", "unknown"),
+                                        tool_name=next(
+                                            (
+                                                tc["function"]["name"]
+                                                for tc in current_turn_tool_calls
+                                                if tc["id"] == tool_call_id
+                                            ),
+                                            "unknown",
+                                        ),
                                         content=tool_output_content,
                                     )
                                 ),


### PR DESCRIPTION
## Summary

Fixes an issue where `ToolResultEvent.data.result.tool_name` was always `"unknown"` for non-MCP tool calls in `OpenAIBaseAgent`.

## Cause

In the `tool_output` branch, the tool name was retrieved using:

```python
getattr(raw_item, "name", "unknown")
```                                                                                                                                                                                            
But on a `tool_output` item, `raw_item`  payload doesn't carry the function name. Only the original `tool_called` raw_item does. The MCP path is unaffected.                                                                                                                                                                                             
                  
## Fix                                                                                                                                                                                                          
Look the name up by `tool_call_id` from `current_turn_tool_calls`, which the `tool_called` branch already populates. Keeps `"unknown"` as a final fallback.  