### PR TITLE
feat: Update CM1 experiment-analysis Stage 5 

### DIFF
--- a/akd_ext/agents/closed_loop/cm1/agents.py
+++ b/akd_ext/agents/closed_loop/cm1/agents.py
@@ -240,6 +240,13 @@ class CM1ExperimentAnalysisConfig(ExperimentAnalysisConfig):
     """CM1-specific configuration for the Experiment Analysis Agent."""
 
     system_prompt: str = Field(default=DATA_ANALYSIS_SYSTEM_PROMPT)
+    # gpt-5.2 (reasoning) instead of the nano default so the conversational
+    # turns are higher quality AND surface a live "thinking" trace. summary
+    # "detailed" is required — "auto" skips the summary for short reasoning,
+    # which left the chat looking frozen/dead while the model worked.
+    model_name: str = Field(default="gpt-5.2")
+    reasoning_effort: Literal["low", "medium", "high"] | None = Field(default="low")
+    reasoning_summary: Literal["auto", "detailed", "concise"] | None = Field(default="detailed")
     description: str = Field(
         default="Experiment Analysis Agent for CM1 experiments. A conversational "
         "orchestrator covering the full post-experiment analysis lifecycle: it "
@@ -793,6 +800,11 @@ class CM1ExperimentAnalysisAgent(ExperimentAnalysisAgent):
         if (params.message or "").strip():
             return params.message.strip()
 
+        # LangGraph/UI driver delivers the reply as 'query' (inputs.<node>.query
+        # on resume) instead of 'message'. Treat it as the same chat turn.
+        if (getattr(params, "query", None) or "").strip():
+            return params.query.strip()
+
         hr = getattr(run_context, "human_response", None)
         content = getattr(hr, "content", None)
         if content:
@@ -860,6 +872,11 @@ class CM1ExperimentAnalysisAgent(ExperimentAnalysisAgent):
         **kwargs: Any,
     ) -> AsyncIterator[StreamEvent]:
         cn = self.__class__.__name__
+        # Immediate feedback so the chat doesn't look dead while we route. The
+        # intent-classification LLM call below takes a beat before the
+        # phase-specific "Designing…/Checking…/Analyzing…" line appears, so emit
+        # a generic progress line the instant the turn arrives.
+        yield RunningEvent(source=cn, message="Thinking…", run_context=run_context)
         # Resolve the user's turn from run_context (LangGraph) or message
         # (notebook), then make it visible to the downstream helpers.
         params = params.model_copy(update={"message": self._resolve_turn(params, run_context)})

--- a/akd_ext/agents/closed_loop/cm1/tools.py
+++ b/akd_ext/agents/closed_loop/cm1/tools.py
@@ -68,7 +68,26 @@ def get_default_impl_tools() -> list[OpenAITool]:
 
 
 def get_default_report_tools() -> list[OpenAITool]:
-    """Default tools for the Research Report Generator. Uses job management MCP server."""
+    """Default tools for the Research Report Generator. Uses job management MCP server.
+
+    Auth is passed via ``headers`` (a real header dict), NOT a top-level
+    ``authorization`` field: the OpenAI hosted-MCP tool_config only honors
+    ``headers``. Sending ``authorization`` was silently ignored, so OpenAI
+    connected to the (bearer-protected) FastMCP server with no credential, got
+    a 401, and the Responses streaming call failed with a generic 500
+    ("An error occurred while processing your request"). This mirrors
+    ``get_default_impl_tools`` (which already worked).
+    """
+    # Prefer the dedicated status endpoint, but fall back to the CM1 job
+    # server (same job_submit/job_status/job_plot contract) when it isn't
+    # configured separately — newer deployments route everything through
+    # CM1_MCP_* and don't set EXPERIMENT_STATUS_MCP_*.
+    api_key = os.environ.get("EXPERIMENT_STATUS_MCP_KEY") or os.environ.get("CM1_MCP_API_KEY")
+    url = os.environ.get("EXPERIMENT_STATUS_MCP_URL") or os.environ.get("CM1_MCP_URL")
+    if not api_key or not url:
+        # Not configured — skip the tool rather than emit one with no/blank auth
+        # that 500s the model call.
+        return []
     return [
         HostedMCPTool(
             tool_config={
@@ -80,11 +99,8 @@ def get_default_report_tools() -> list[OpenAITool]:
                 ],
                 "require_approval": "never",
                 "server_description": "MCP server for checking CM1 experiment job status and fetching result figures",
-                "server_url": os.environ.get(
-                    "EXPERIMENT_STATUS_MCP_URL",
-                    "",  # No default — must be configured
-                ),
-                "authorization": os.environ.get("EXPERIMENT_STATUS_MCP_KEY"),
+                "server_url": url,
+                "headers": _mcp_auth_headers(api_key, url),
             }
         ),
     ]

--- a/akd_ext/agents/closed_loop/stages/experiment_analysis.py
+++ b/akd_ext/agents/closed_loop/stages/experiment_analysis.py
@@ -286,6 +286,14 @@ class ExperimentAnalysisInputSchema(InputSchema):
             "The non-interactive base agent ignores it."
         ),
     )
+    query: str | None = Field(
+        default=None,
+        description=(
+            "Alias for the user's chat turn under the LangGraph/UI driver, "
+            "which delivers the reply as 'query' (inputs.<node>.query on resume) "
+            "rather than 'message'. Resolved alongside 'message'."
+        ),
+    )
 
 
 class ExperimentAnalysisOutputSchema(OutputSchema):


### PR DESCRIPTION
### Summary
- Fixes the CM1 Research Report Generator and Improves the CM1 Experiment Analysis chat with a thinking trace between sub agent
- Handles the chat turn arriving as query in addition to message.

### What changed

- cm1/tools.py:  Report generator's MCP tool now sends auth via headers

-  cm1/agents.py: 
Analysis agent now uses gpt-5.2 (reasoning, effort low, summary detailed) instead of the nano default → higher-quality turns + a live reasoning trace (detailed is required, else short reasoning skips the summary and the chat looks frozen).

- stages/experiment_analysis.py:  Adds a query field to the input schema (alias for the chat turn under the LangGraph/UI driver, resolved alongside message).

### How to test
- Run the CM1 Agent
